### PR TITLE
Extended plugin functionality with zones, segments and HDR preview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(REQUIRED_LIBS_QUALIFIED Qt${QT_VERSION}::Core Qt${QT_VERSION}::Gui Qt${QT_VE
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
 
-add_library(${PROJECT_NAME} SHARED OpenRGBAmbientPlugin.h OpenRGBAmbientPlugin.cpp DeviceList.cpp DeviceList.h Settings.cpp Settings.h ScreenCapture.cpp ScreenCapture.h Limiter.cpp Limiter.h ReleaseWrapper.h SettingsTab.cpp SettingsTab.h RegionsWidget.cpp RegionsWidget.h RegionWidget.cpp RegionWidget.h LedUpdateEvent.h LedUpdateEvent.cpp ImageProcessor.h LedRange.h SdrHorizontalRegionProcessor.h SdrVerticalRegionProcessor.h ColorConversion.h HdrVerticalRegionProcessor.h HdrHorizontalRegionProcessor.h ColorPostProcessor.h)
+add_library(${PROJECT_NAME} SHARED OpenRGBAmbientPlugin.h OpenRGBAmbientPlugin.cpp DeviceList.cpp DeviceList.h Settings.cpp Settings.h ScreenCapture.cpp ScreenCapture.h Limiter.cpp Limiter.h ReleaseWrapper.h SettingsTab.cpp SettingsTab.h RegionsWidget.cpp RegionsWidget.h RegionWidget.cpp RegionWidget.h LedUpdateEvent.h LedUpdateEvent.cpp ImageProcessor.h LedRange.h ZoneMapping.h SdrHorizontalRegionProcessor.h SdrVerticalRegionProcessor.h ColorConversion.h HdrVerticalRegionProcessor.h HdrHorizontalRegionProcessor.h ColorPostProcessor.h LedPreviewWidget.h LedPreviewWidget.cpp)
 
 if (WIN32)
     add_definitions(-D_MBCS -DWIN32 -D_CRT_SECURE_NO_WARNINGS -D_WINSOCKAPI_ -D_WINSOCK_DEPRECATED_NO_WARNINGS -DWIN32_LEAN_AND_MEAN -DNOMINMAX)
@@ -27,6 +27,8 @@ if (NOT CMAKE_PREFIX_PATH)
     message(WARNING "CMAKE_PREFIX_PATH is not defined, you may need to set it "
             "(-DCMAKE_PREFIX_PATH=\"path/to/Qt/lib/cmake\" or -DCMAKE_PREFIX_PATH=/usr/include/{host}/qt{version}/ on Ubuntu)")
 endif ()
+
+include(C:/NowProj/AL_Controller/OpenRGB-Ambient/vcpkg/scripts/buildsystems/vcpkg.cmake)
 
 find_package(Qt${QT_VERSION} COMPONENTS ${REQUIRED_LIBS} REQUIRED)
 find_package(DirectX11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,9 @@ if (NOT CMAKE_PREFIX_PATH)
             "(-DCMAKE_PREFIX_PATH=\"path/to/Qt/lib/cmake\" or -DCMAKE_PREFIX_PATH=/usr/include/{host}/qt{version}/ on Ubuntu)")
 endif ()
 
-include(C:/NowProj/AL_Controller/OpenRGB-Ambient/vcpkg/scripts/buildsystems/vcpkg.cmake)
+if(EXISTS "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
+    include("${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
+endif()
 
 find_package(Qt${QT_VERSION} COMPONENTS ${REQUIRED_LIBS} REQUIRED)
 find_package(DirectX11)

--- a/DeviceList.cpp
+++ b/DeviceList.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 
 #include <QHBoxLayout>
-#include <QTreeWidget>
+#include <QListWidget>
 
 #include <ResourceManager.h>
 #include <RGBController.h>
@@ -13,8 +13,7 @@
 
 #include "DeviceList.h"
 
-static constexpr int LOC_ROLE      = Qt::UserRole;
-static constexpr int ZONE_NAME_ROLE = Qt::UserRole + 1;
+static constexpr int LOC_ROLE = Qt::UserRole;
 
 DeviceList::DeviceList(ResourceManagerInterface *resourceManager, Settings &settings, QWidget *parent)
     : QWidget{parent}
@@ -23,19 +22,11 @@ DeviceList::DeviceList(ResourceManagerInterface *resourceManager, Settings &sett
 {
     const auto layout = new QHBoxLayout{this};
 
-    deviceList = new QTreeWidget{};
-    deviceList->setHeaderHidden(true);
-    deviceList->setRootIsDecorated(true);
-
-    connect(deviceList, &QTreeWidget::itemChanged, this, &DeviceList::onItemChanged);
-    connect(deviceList, &QTreeWidget::currentItemChanged, this, [this](QTreeWidgetItem *current, QTreeWidgetItem *) {
-        if (current == nullptr)
-            return;
-        const auto location = current->data(LOC_ROLE, Qt::DisplayRole).toString();
-        // data stored via setData(column, role, value) — use column 0
-        const auto loc = current->data(0, LOC_ROLE).toString();
-        if (!loc.isEmpty())
-            emit controllerSelected(loc);
+    deviceList = new QListWidget{};
+    connect(deviceList, &QListWidget::itemChanged, this, &DeviceList::onItemChanged);
+    connect(deviceList, &QListWidget::currentItemChanged, this, [this](QListWidgetItem *current, QListWidgetItem *) {
+        if (current != nullptr)
+            emit controllerSelected(current->data(LOC_ROLE).toString());
     });
 
     layout->addWidget(deviceList);
@@ -43,63 +34,34 @@ DeviceList::DeviceList(ResourceManagerInterface *resourceManager, Settings &sett
 
 void DeviceList::fillControllerList() const
 {
-    const QSignalBlocker blocker{deviceList};
-    deviceList->clear();
-
-    const auto &controllers = resourceManager->GetRGBControllers();
-    for (const auto controller : controllers)
     {
-        if (std::ranges::none_of(controller->modes, [](const auto &mode) {
-            return mode.name == "Direct";
-        }))
-            continue;
+        const QSignalBlocker blocker{deviceList};
+        deviceList->clear();
 
-        const auto location = QString::fromStdString(controller->location);
-        const bool ctrlSelected = settings.isControllerSelected(controller->location);
-
-        auto *ctrlItem = new QTreeWidgetItem{deviceList};
-        ctrlItem->setText(0, QString::fromStdString(controller->name));
-        ctrlItem->setData(0, LOC_ROLE, location);
-        ctrlItem->setCheckState(0, ctrlSelected ? Qt::Checked : Qt::Unchecked);
-
-        for (const auto &zone : controller->zones)
+        const auto &controllers = resourceManager->GetRGBControllers();
+        for (const auto controller : controllers)
         {
-            const auto zoneName = QString::fromStdString(zone.name);
+            if (std::ranges::none_of(controller->modes, [](const auto &mode) {
+                return mode.name == "Direct";
+            }))
+                continue;
 
-            auto *zoneItem = new QTreeWidgetItem{ctrlItem};
-            zoneItem->setText(0, zoneName);
-            zoneItem->setData(0, LOC_ROLE, location);
-            zoneItem->setData(0, ZONE_NAME_ROLE, zoneName);
-            zoneItem->setCheckState(0, settings.isZoneEnabled(controller->location, zone.name) ? Qt::Checked : Qt::Unchecked);
-            zoneItem->setDisabled(!ctrlSelected);
+            const auto item = new QListWidgetItem{QString::fromStdString(controller->name)};
+            item->setData(LOC_ROLE, QString::fromStdString(controller->location));
+            item->setCheckState(settings.isControllerSelected(controller->location) ? Qt::Checked : Qt::Unchecked);
+            deviceList->addItem(item);
         }
-
-        ctrlItem->setExpanded(true);
     }
+
+    if (deviceList->count() > 0)
+        deviceList->setCurrentRow(0);
 }
 
-void DeviceList::onItemChanged(QTreeWidgetItem *item, int) const
+void DeviceList::onItemChanged(QListWidgetItem *item) const
 {
-    const QSignalBlocker blocker{deviceList};
-
-    const auto location = item->data(0, LOC_ROLE).toString().toStdString();
-    const bool checked  = item->checkState(0) == Qt::Checked;
-
-    if (item->parent() == nullptr)
-    {
-        // Controller item
-        if (checked)
-            settings.selectController(location);
-        else
-            settings.unselectController(location);
-
-        for (int i = 0; i < item->childCount(); ++i)
-            item->child(i)->setDisabled(!checked);
-    }
+    const auto location = item->data(LOC_ROLE).toString().toStdString();
+    if (item->checkState() == Qt::Checked)
+        settings.selectController(location);
     else
-    {
-        // Zone item
-        const auto zoneName = item->data(0, ZONE_NAME_ROLE).toString().toStdString();
-        settings.setZoneEnabled(location, zoneName, checked);
-    }
+        settings.unselectController(location);
 }

--- a/DeviceList.cpp
+++ b/DeviceList.cpp
@@ -4,15 +4,17 @@
 #include <algorithm>
 
 #include <QHBoxLayout>
-#include <QListWidget>
+#include <QTreeWidget>
 
 #include <ResourceManager.h>
+#include <RGBController.h>
 
 #include "Settings.h"
 
 #include "DeviceList.h"
 
-#include <RGBController.h>
+static constexpr int LOC_ROLE      = Qt::UserRole;
+static constexpr int ZONE_NAME_ROLE = Qt::UserRole + 1;
 
 DeviceList::DeviceList(ResourceManagerInterface *resourceManager, Settings &settings, QWidget *parent)
     : QWidget{parent}
@@ -21,11 +23,19 @@ DeviceList::DeviceList(ResourceManagerInterface *resourceManager, Settings &sett
 {
     const auto layout = new QHBoxLayout{this};
 
-    deviceList = new QListWidget{};
-    connect(deviceList, &QListWidget::itemChanged, this, &DeviceList::saveCheckState);
-    connect(deviceList, &QListWidget::currentItemChanged, this, [this](auto current, auto previous) {
-        if (current != nullptr)
-            emit controllerSelected(current->data(Qt::UserRole).toString());
+    deviceList = new QTreeWidget{};
+    deviceList->setHeaderHidden(true);
+    deviceList->setRootIsDecorated(true);
+
+    connect(deviceList, &QTreeWidget::itemChanged, this, &DeviceList::onItemChanged);
+    connect(deviceList, &QTreeWidget::currentItemChanged, this, [this](QTreeWidgetItem *current, QTreeWidgetItem *) {
+        if (current == nullptr)
+            return;
+        const auto location = current->data(LOC_ROLE, Qt::DisplayRole).toString();
+        // data stored via setData(column, role, value) — use column 0
+        const auto loc = current->data(0, LOC_ROLE).toString();
+        if (!loc.isEmpty())
+            emit controllerSelected(loc);
     });
 
     layout->addWidget(deviceList);
@@ -33,6 +43,7 @@ DeviceList::DeviceList(ResourceManagerInterface *resourceManager, Settings &sett
 
 void DeviceList::fillControllerList() const
 {
+    const QSignalBlocker blocker{deviceList};
     deviceList->clear();
 
     const auto &controllers = resourceManager->GetRGBControllers();
@@ -41,23 +52,54 @@ void DeviceList::fillControllerList() const
         if (std::ranges::none_of(controller->modes, [](const auto &mode) {
             return mode.name == "Direct";
         }))
-        {
             continue;
+
+        const auto location = QString::fromStdString(controller->location);
+        const bool ctrlSelected = settings.isControllerSelected(controller->location);
+
+        auto *ctrlItem = new QTreeWidgetItem{deviceList};
+        ctrlItem->setText(0, QString::fromStdString(controller->name));
+        ctrlItem->setData(0, LOC_ROLE, location);
+        ctrlItem->setCheckState(0, ctrlSelected ? Qt::Checked : Qt::Unchecked);
+
+        for (const auto &zone : controller->zones)
+        {
+            const auto zoneName = QString::fromStdString(zone.name);
+
+            auto *zoneItem = new QTreeWidgetItem{ctrlItem};
+            zoneItem->setText(0, zoneName);
+            zoneItem->setData(0, LOC_ROLE, location);
+            zoneItem->setData(0, ZONE_NAME_ROLE, zoneName);
+            zoneItem->setCheckState(0, settings.isZoneEnabled(controller->location, zone.name) ? Qt::Checked : Qt::Unchecked);
+            zoneItem->setDisabled(!ctrlSelected);
         }
 
-        const auto item = new QListWidgetItem{QString::fromStdString(controller->name)};
-        item->setCheckState(settings.isControllerSelected(controller->location) ? Qt::Checked : Qt::Unchecked);
-        item->setData(Qt::UserRole, QString::fromStdString(controller->location));
-
-        deviceList->addItem(item);
+        ctrlItem->setExpanded(true);
     }
 }
 
-void DeviceList::saveCheckState(QListWidgetItem *item) const
+void DeviceList::onItemChanged(QTreeWidgetItem *item, int) const
 {
-    const auto location = item->data(Qt::UserRole).toString().toStdString();
-    if (item->checkState() == Qt::Checked)
-        settings.selectController(location);
+    const QSignalBlocker blocker{deviceList};
+
+    const auto location = item->data(0, LOC_ROLE).toString().toStdString();
+    const bool checked  = item->checkState(0) == Qt::Checked;
+
+    if (item->parent() == nullptr)
+    {
+        // Controller item
+        if (checked)
+            settings.selectController(location);
+        else
+            settings.unselectController(location);
+
+        for (int i = 0; i < item->childCount(); ++i)
+            item->child(i)->setDisabled(!checked);
+    }
     else
-        settings.unselectController(location);
+    {
+        // Zone item
+        const auto zoneName = item->data(0, ZONE_NAME_ROLE).toString().toStdString();
+        settings.setZoneEnabled(location, zoneName, checked);
+    }
 }

--- a/DeviceList.h
+++ b/DeviceList.h
@@ -8,8 +8,8 @@
 #include <QWidget>
 
 class ResourceManagerInterface;
-class QTreeWidgetItem;
-class QTreeWidget;
+class QListWidgetItem;
+class QListWidget;
 class Settings;
 
 class DeviceList
@@ -28,12 +28,12 @@ public slots:
     void fillControllerList() const;
 
 private slots:
-    void onItemChanged(QTreeWidgetItem *item, int column) const;
+    void onItemChanged(QListWidgetItem *item) const;
 
 private:
     ResourceManagerInterface *resourceManager;
     Settings &settings;
-    QTreeWidget *deviceList;
+    QListWidget *deviceList;
 };
 
 #endif //OPENRGB_AMBIENT_DEVICELIST_H

--- a/DeviceList.h
+++ b/DeviceList.h
@@ -8,8 +8,8 @@
 #include <QWidget>
 
 class ResourceManagerInterface;
-class QListWidgetItem;
-class QListWidget;
+class QTreeWidgetItem;
+class QTreeWidget;
 class Settings;
 
 class DeviceList
@@ -26,12 +26,14 @@ signals:
 
 public slots:
     void fillControllerList() const;
-    void saveCheckState(QListWidgetItem *item) const;
+
+private slots:
+    void onItemChanged(QTreeWidgetItem *item, int column) const;
 
 private:
     ResourceManagerInterface *resourceManager;
     Settings &settings;
-    QListWidget *deviceList;
+    QTreeWidget *deviceList;
 };
 
 #endif //OPENRGB_AMBIENT_DEVICELIST_H

--- a/ImageProcessor.h
+++ b/ImageProcessor.h
@@ -46,6 +46,7 @@ public:
                    const std::vector<ZoneLedRange> &zoneMappings,
                    std::array<float, 3> colorFactors,
                    CPP colorPostProcessor,
+                   bool useZoneMapping,
                    QObject *eventReceiver)
             : controllerLocation{std::move(controllerLocation)}
             , eventReceiver{eventReceiver}
@@ -62,6 +63,7 @@ public:
             , leftHdrProcessor{leftRange.getLength(), colorFactors, colorPostProcessor}
             , rightHdrProcessor{rightRange.getLength(), colorFactors, colorPostProcessor}
             , colors(totalLeds)
+            , useZoneMapping{useZoneMapping}
     {
         for (const auto &z : zoneMappings)
         {
@@ -104,42 +106,47 @@ public:
         const auto realRight = std::min(rightRange.from, rightRange.to);
         const auto realLeft = std::min(leftRange.from, leftRange.to);
 
-        topSdrProcessor.processRegion(colors.data() + realTop, data, width, sampleHeight, stridePixels);
-        bottomSdrProcessor.processRegion(colors.data() + realBottom, data + 4 * stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
-        leftSdrProcessor.processRegion(colors.data() + realLeft, data, sampleWidth, height, 0, stridePixels);
-        rightSdrProcessor.processRegion(colors.data() + realRight, data, sampleWidth, height, width - sampleWidth, stridePixels);
-
-        for (auto i = 0u; i < topZoneEntries.size(); ++i)
+        if (!useZoneMapping)
         {
-            const auto start = std::min(topZoneEntries[i].range.from, topZoneEntries[i].range.to);
-            const auto len = topZoneEntries[i].range.getLength();
-            topSdrZoneProcs[i].processRegion(colors.data() + start, data, width, sampleHeight, stridePixels);
-            if (topZoneEntries[i].reversed)
-                std::reverse(colors.data() + start, colors.data() + start + len);
+            topSdrProcessor.processRegion(colors.data() + realTop, data, width, sampleHeight, stridePixels);
+            bottomSdrProcessor.processRegion(colors.data() + realBottom, data + 4 * stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
+            leftSdrProcessor.processRegion(colors.data() + realLeft, data, sampleWidth, height, 0, stridePixels);
+            rightSdrProcessor.processRegion(colors.data() + realRight, data, sampleWidth, height, width - sampleWidth, stridePixels);
         }
-        for (auto i = 0u; i < bottomZoneEntries.size(); ++i)
+        else
         {
-            const auto start = std::min(bottomZoneEntries[i].range.from, bottomZoneEntries[i].range.to);
-            const auto len = bottomZoneEntries[i].range.getLength();
-            bottomSdrZoneProcs[i].processRegion(colors.data() + start, data + 4 * stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
-            if (bottomZoneEntries[i].reversed)
-                std::reverse(colors.data() + start, colors.data() + start + len);
-        }
-        for (auto i = 0u; i < leftZoneEntries.size(); ++i)
-        {
-            const auto start = std::min(leftZoneEntries[i].range.from, leftZoneEntries[i].range.to);
-            const auto len = leftZoneEntries[i].range.getLength();
-            leftSdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, 0, stridePixels);
-            if (leftZoneEntries[i].reversed)
-                std::reverse(colors.data() + start, colors.data() + start + len);
-        }
-        for (auto i = 0u; i < rightZoneEntries.size(); ++i)
-        {
-            const auto start = std::min(rightZoneEntries[i].range.from, rightZoneEntries[i].range.to);
-            const auto len = rightZoneEntries[i].range.getLength();
-            rightSdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, width - sampleWidth, stridePixels);
-            if (rightZoneEntries[i].reversed)
-                std::reverse(colors.data() + start, colors.data() + start + len);
+            for (auto i = 0u; i < topZoneEntries.size(); ++i)
+            {
+                const auto start = std::min(topZoneEntries[i].range.from, topZoneEntries[i].range.to);
+                const auto len = topZoneEntries[i].range.getLength();
+                topSdrZoneProcs[i].processRegion(colors.data() + start, data, width, sampleHeight, stridePixels);
+                if (topZoneEntries[i].reversed)
+                    std::reverse(colors.data() + start, colors.data() + start + len);
+            }
+            for (auto i = 0u; i < bottomZoneEntries.size(); ++i)
+            {
+                const auto start = std::min(bottomZoneEntries[i].range.from, bottomZoneEntries[i].range.to);
+                const auto len = bottomZoneEntries[i].range.getLength();
+                bottomSdrZoneProcs[i].processRegion(colors.data() + start, data + 4 * stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
+                if (bottomZoneEntries[i].reversed)
+                    std::reverse(colors.data() + start, colors.data() + start + len);
+            }
+            for (auto i = 0u; i < leftZoneEntries.size(); ++i)
+            {
+                const auto start = std::min(leftZoneEntries[i].range.from, leftZoneEntries[i].range.to);
+                const auto len = leftZoneEntries[i].range.getLength();
+                leftSdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, 0, stridePixels);
+                if (leftZoneEntries[i].reversed)
+                    std::reverse(colors.data() + start, colors.data() + start + len);
+            }
+            for (auto i = 0u; i < rightZoneEntries.size(); ++i)
+            {
+                const auto start = std::min(rightZoneEntries[i].range.from, rightZoneEntries[i].range.to);
+                const auto len = rightZoneEntries[i].range.getLength();
+                rightSdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, width - sampleWidth, stridePixels);
+                if (rightZoneEntries[i].reversed)
+                    std::reverse(colors.data() + start, colors.data() + start + len);
+            }
         }
 
         QCoreApplication::postEvent(eventReceiver, new LedUpdateEvent{controllerLocation, colors});
@@ -155,42 +162,47 @@ public:
         const auto realRight = std::min(rightRange.from, rightRange.to);
         const auto realLeft = std::min(leftRange.from, leftRange.to);
 
-        topHdrProcessor.processRegion(colors.data() + realTop, data, width, sampleHeight, stridePixels);
-        bottomHdrProcessor.processRegion(colors.data() + realBottom, data + stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
-        leftHdrProcessor.processRegion(colors.data() + realLeft, data, sampleWidth, height, 0, stridePixels);
-        rightHdrProcessor.processRegion(colors.data() + realRight, data, sampleWidth, height, width - sampleWidth, stridePixels);
-
-        for (auto i = 0u; i < topZoneEntries.size(); ++i)
+        if (!useZoneMapping)
         {
-            const auto start = std::min(topZoneEntries[i].range.from, topZoneEntries[i].range.to);
-            const auto len = topZoneEntries[i].range.getLength();
-            topHdrZoneProcs[i].processRegion(colors.data() + start, data, width, sampleHeight, stridePixels);
-            if (topZoneEntries[i].reversed)
-                std::reverse(colors.data() + start, colors.data() + start + len);
+            topHdrProcessor.processRegion(colors.data() + realTop, data, width, sampleHeight, stridePixels);
+            bottomHdrProcessor.processRegion(colors.data() + realBottom, data + stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
+            leftHdrProcessor.processRegion(colors.data() + realLeft, data, sampleWidth, height, 0, stridePixels);
+            rightHdrProcessor.processRegion(colors.data() + realRight, data, sampleWidth, height, width - sampleWidth, stridePixels);
         }
-        for (auto i = 0u; i < bottomZoneEntries.size(); ++i)
+        else
         {
-            const auto start = std::min(bottomZoneEntries[i].range.from, bottomZoneEntries[i].range.to);
-            const auto len = bottomZoneEntries[i].range.getLength();
-            bottomHdrZoneProcs[i].processRegion(colors.data() + start, data + stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
-            if (bottomZoneEntries[i].reversed)
-                std::reverse(colors.data() + start, colors.data() + start + len);
-        }
-        for (auto i = 0u; i < leftZoneEntries.size(); ++i)
-        {
-            const auto start = std::min(leftZoneEntries[i].range.from, leftZoneEntries[i].range.to);
-            const auto len = leftZoneEntries[i].range.getLength();
-            leftHdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, 0, stridePixels);
-            if (leftZoneEntries[i].reversed)
-                std::reverse(colors.data() + start, colors.data() + start + len);
-        }
-        for (auto i = 0u; i < rightZoneEntries.size(); ++i)
-        {
-            const auto start = std::min(rightZoneEntries[i].range.from, rightZoneEntries[i].range.to);
-            const auto len = rightZoneEntries[i].range.getLength();
-            rightHdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, width - sampleWidth, stridePixels);
-            if (rightZoneEntries[i].reversed)
-                std::reverse(colors.data() + start, colors.data() + start + len);
+            for (auto i = 0u; i < topZoneEntries.size(); ++i)
+            {
+                const auto start = std::min(topZoneEntries[i].range.from, topZoneEntries[i].range.to);
+                const auto len = topZoneEntries[i].range.getLength();
+                topHdrZoneProcs[i].processRegion(colors.data() + start, data, width, sampleHeight, stridePixels);
+                if (topZoneEntries[i].reversed)
+                    std::reverse(colors.data() + start, colors.data() + start + len);
+            }
+            for (auto i = 0u; i < bottomZoneEntries.size(); ++i)
+            {
+                const auto start = std::min(bottomZoneEntries[i].range.from, bottomZoneEntries[i].range.to);
+                const auto len = bottomZoneEntries[i].range.getLength();
+                bottomHdrZoneProcs[i].processRegion(colors.data() + start, data + stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
+                if (bottomZoneEntries[i].reversed)
+                    std::reverse(colors.data() + start, colors.data() + start + len);
+            }
+            for (auto i = 0u; i < leftZoneEntries.size(); ++i)
+            {
+                const auto start = std::min(leftZoneEntries[i].range.from, leftZoneEntries[i].range.to);
+                const auto len = leftZoneEntries[i].range.getLength();
+                leftHdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, 0, stridePixels);
+                if (leftZoneEntries[i].reversed)
+                    std::reverse(colors.data() + start, colors.data() + start + len);
+            }
+            for (auto i = 0u; i < rightZoneEntries.size(); ++i)
+            {
+                const auto start = std::min(rightZoneEntries[i].range.from, rightZoneEntries[i].range.to);
+                const auto len = rightZoneEntries[i].range.getLength();
+                rightHdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, width - sampleWidth, stridePixels);
+                if (rightZoneEntries[i].reversed)
+                    std::reverse(colors.data() + start, colors.data() + start + len);
+            }
         }
 
         QCoreApplication::postEvent(eventReceiver, new LedUpdateEvent{controllerLocation, colors});
@@ -202,6 +214,7 @@ private:
 
     std::string controllerLocation;
     QObject *eventReceiver;
+    bool useZoneMapping = false;
 
     LedRange topRange;
     LedRange bottomRange;

--- a/ImageProcessor.h
+++ b/ImageProcessor.h
@@ -21,6 +21,7 @@
 #include "ColorPostProcessor.h"
 #include "LedUpdateEvent.h"
 #include "LedRange.h"
+#include "ZoneMapping.h"
 
 class QObject;
 
@@ -37,10 +38,12 @@ class ImageProcessor final
 {
 public:
     ImageProcessor(std::string controllerLocation,
+                   int totalLeds,
                    LedRange topRange,
                    LedRange bottomRange,
                    LedRange rightRange,
                    LedRange leftRange,
+                   std::vector<ZoneLedRange> zoneMappings,
                    std::array<float, 3> colorFactors,
                    CPP colorPostProcessor,
                    QObject *eventReceiver)
@@ -58,8 +61,37 @@ public:
             , bottomHdrProcessor{bottomRange.getLength(), colorFactors, colorPostProcessor}
             , leftHdrProcessor{leftRange.getLength(), colorFactors, colorPostProcessor}
             , rightHdrProcessor{rightRange.getLength(), colorFactors, colorPostProcessor}
-            , colors(topRange.getLength() + bottomRange.getLength() + leftRange.getLength() + rightRange.getLength())
+            , colors(totalLeds)
     {
+        for (const auto &z : zoneMappings)
+        {
+            const auto len = z.range.getLength();
+            switch (z.region)
+            {
+                case ScreenRegion::Top:
+                    topZoneEntries.push_back({z.range, z.reversed});
+                    topSdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
+                    topHdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
+                    break;
+                case ScreenRegion::Bottom:
+                    bottomZoneEntries.push_back({z.range, z.reversed});
+                    bottomSdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
+                    bottomHdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
+                    break;
+                case ScreenRegion::Left:
+                    leftZoneEntries.push_back({z.range, z.reversed});
+                    leftSdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
+                    leftHdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
+                    break;
+                case ScreenRegion::Right:
+                    rightZoneEntries.push_back({z.range, z.reversed});
+                    rightSdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
+                    rightHdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 
     void processSdrImage(const uchar *data, int width, int height, int stridePixels) override
@@ -76,6 +108,39 @@ public:
         bottomSdrProcessor.processRegion(colors.data() + realBottom, data + 4 * stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
         leftSdrProcessor.processRegion(colors.data() + realLeft, data, sampleWidth, height, 0, stridePixels);
         rightSdrProcessor.processRegion(colors.data() + realRight, data, sampleWidth, height, width - sampleWidth, stridePixels);
+
+        for (auto i = 0u; i < topZoneEntries.size(); ++i)
+        {
+            const auto start = std::min(topZoneEntries[i].range.from, topZoneEntries[i].range.to);
+            const auto len = topZoneEntries[i].range.getLength();
+            topSdrZoneProcs[i].processRegion(colors.data() + start, data, width, sampleHeight, stridePixels);
+            if (topZoneEntries[i].reversed)
+                std::reverse(colors.data() + start, colors.data() + start + len);
+        }
+        for (auto i = 0u; i < bottomZoneEntries.size(); ++i)
+        {
+            const auto start = std::min(bottomZoneEntries[i].range.from, bottomZoneEntries[i].range.to);
+            const auto len = bottomZoneEntries[i].range.getLength();
+            bottomSdrZoneProcs[i].processRegion(colors.data() + start, data + 4 * stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
+            if (bottomZoneEntries[i].reversed)
+                std::reverse(colors.data() + start, colors.data() + start + len);
+        }
+        for (auto i = 0u; i < leftZoneEntries.size(); ++i)
+        {
+            const auto start = std::min(leftZoneEntries[i].range.from, leftZoneEntries[i].range.to);
+            const auto len = leftZoneEntries[i].range.getLength();
+            leftSdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, 0, stridePixels);
+            if (leftZoneEntries[i].reversed)
+                std::reverse(colors.data() + start, colors.data() + start + len);
+        }
+        for (auto i = 0u; i < rightZoneEntries.size(); ++i)
+        {
+            const auto start = std::min(rightZoneEntries[i].range.from, rightZoneEntries[i].range.to);
+            const auto len = rightZoneEntries[i].range.getLength();
+            rightSdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, width - sampleWidth, stridePixels);
+            if (rightZoneEntries[i].reversed)
+                std::reverse(colors.data() + start, colors.data() + start + len);
+        }
 
         QCoreApplication::postEvent(eventReceiver, new LedUpdateEvent{controllerLocation, colors});
     }
@@ -94,6 +159,39 @@ public:
         bottomHdrProcessor.processRegion(colors.data() + realBottom, data + stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
         leftHdrProcessor.processRegion(colors.data() + realLeft, data, sampleWidth, height, 0, stridePixels);
         rightHdrProcessor.processRegion(colors.data() + realRight, data, sampleWidth, height, width - sampleWidth, stridePixels);
+
+        for (auto i = 0u; i < topZoneEntries.size(); ++i)
+        {
+            const auto start = std::min(topZoneEntries[i].range.from, topZoneEntries[i].range.to);
+            const auto len = topZoneEntries[i].range.getLength();
+            topHdrZoneProcs[i].processRegion(colors.data() + start, data, width, sampleHeight, stridePixels);
+            if (topZoneEntries[i].reversed)
+                std::reverse(colors.data() + start, colors.data() + start + len);
+        }
+        for (auto i = 0u; i < bottomZoneEntries.size(); ++i)
+        {
+            const auto start = std::min(bottomZoneEntries[i].range.from, bottomZoneEntries[i].range.to);
+            const auto len = bottomZoneEntries[i].range.getLength();
+            bottomHdrZoneProcs[i].processRegion(colors.data() + start, data + stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
+            if (bottomZoneEntries[i].reversed)
+                std::reverse(colors.data() + start, colors.data() + start + len);
+        }
+        for (auto i = 0u; i < leftZoneEntries.size(); ++i)
+        {
+            const auto start = std::min(leftZoneEntries[i].range.from, leftZoneEntries[i].range.to);
+            const auto len = leftZoneEntries[i].range.getLength();
+            leftHdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, 0, stridePixels);
+            if (leftZoneEntries[i].reversed)
+                std::reverse(colors.data() + start, colors.data() + start + len);
+        }
+        for (auto i = 0u; i < rightZoneEntries.size(); ++i)
+        {
+            const auto start = std::min(rightZoneEntries[i].range.from, rightZoneEntries[i].range.to);
+            const auto len = rightZoneEntries[i].range.getLength();
+            rightHdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, width - sampleWidth, stridePixels);
+            if (rightZoneEntries[i].reversed)
+                std::reverse(colors.data() + start, colors.data() + start + len);
+        }
 
         QCoreApplication::postEvent(eventReceiver, new LedUpdateEvent{controllerLocation, colors});
     }
@@ -119,6 +217,23 @@ private:
     HdrHorizontalRegionProcessor<CPP> bottomHdrProcessor;
     HdrVerticalRegionProcessor<CPP> leftHdrProcessor;
     HdrVerticalRegionProcessor<CPP> rightHdrProcessor;
+
+    struct ZoneEntry { LedRange range; bool reversed; };
+
+    std::vector<ZoneEntry> topZoneEntries;
+    std::vector<ZoneEntry> bottomZoneEntries;
+    std::vector<ZoneEntry> leftZoneEntries;
+    std::vector<ZoneEntry> rightZoneEntries;
+
+    std::vector<SdrHorizontalRegionProcessor<CPP>> topSdrZoneProcs;
+    std::vector<SdrHorizontalRegionProcessor<CPP>> bottomSdrZoneProcs;
+    std::vector<SdrVerticalRegionProcessor<CPP>>   leftSdrZoneProcs;
+    std::vector<SdrVerticalRegionProcessor<CPP>>   rightSdrZoneProcs;
+
+    std::vector<HdrHorizontalRegionProcessor<CPP>> topHdrZoneProcs;
+    std::vector<HdrHorizontalRegionProcessor<CPP>> bottomHdrZoneProcs;
+    std::vector<HdrVerticalRegionProcessor<CPP>>   leftHdrZoneProcs;
+    std::vector<HdrVerticalRegionProcessor<CPP>>   rightHdrZoneProcs;
 
     std::vector<RGBColor> colors;
 };

--- a/ImageProcessor.h
+++ b/ImageProcessor.h
@@ -73,22 +73,18 @@ public:
                 case ScreenRegion::Top:
                     topZoneEntries.push_back({z.range, z.reversed});
                     topSdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
-                    topHdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
                     break;
                 case ScreenRegion::Bottom:
                     bottomZoneEntries.push_back({z.range, z.reversed});
                     bottomSdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
-                    bottomHdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
                     break;
                 case ScreenRegion::Left:
                     leftZoneEntries.push_back({z.range, z.reversed});
                     leftSdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
-                    leftHdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
                     break;
                 case ScreenRegion::Right:
                     rightZoneEntries.push_back({z.range, z.reversed});
                     rightSdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
-                    rightHdrZoneProcs.emplace_back(len, colorFactors, colorPostProcessor);
                     break;
                 default:
                     break;
@@ -171,37 +167,95 @@ public:
         }
         else
         {
-            for (auto i = 0u; i < topZoneEntries.size(); ++i)
+            if (!topZoneEntries.empty())
             {
-                const auto start = std::min(topZoneEntries[i].range.from, topZoneEntries[i].range.to);
-                const auto len = topZoneEntries[i].range.getLength();
-                topHdrZoneProcs[i].processRegion(colors.data() + start, data, width, sampleHeight, stridePixels);
-                if (topZoneEntries[i].reversed)
-                    std::reverse(colors.data() + start, colors.data() + start + len);
+                hdrTopCache.resize(static_cast<size_t>(4 * width * sampleHeight));
+                for (int y = 0; y < sampleHeight; ++y)
+                    for (int x = 0; x < width; ++x)
+                    {
+                        const auto p = data[y * stridePixels + x];
+                        const auto idx = 4 * (y * width + x);
+                        hdrTopCache[idx]     = static_cast<uchar>(((p >> 20) & 0x3ffu) >> 2);
+                        hdrTopCache[idx + 1] = static_cast<uchar>(((p >> 10) & 0x3ffu) >> 2);
+                        hdrTopCache[idx + 2] = static_cast<uchar>((p & 0x3ffu) >> 2);
+                        hdrTopCache[idx + 3] = 0;
+                    }
+                for (auto i = 0u; i < topZoneEntries.size(); ++i)
+                {
+                    const auto start = std::min(topZoneEntries[i].range.from, topZoneEntries[i].range.to);
+                    const auto len = topZoneEntries[i].range.getLength();
+                    topSdrZoneProcs[i].processRegion(colors.data() + start, hdrTopCache.data(), width, sampleHeight, width);
+                    if (topZoneEntries[i].reversed)
+                        std::reverse(colors.data() + start, colors.data() + start + len);
+                }
             }
-            for (auto i = 0u; i < bottomZoneEntries.size(); ++i)
+            if (!bottomZoneEntries.empty())
             {
-                const auto start = std::min(bottomZoneEntries[i].range.from, bottomZoneEntries[i].range.to);
-                const auto len = bottomZoneEntries[i].range.getLength();
-                bottomHdrZoneProcs[i].processRegion(colors.data() + start, data + stridePixels * (height - sampleHeight), width, sampleHeight, stridePixels);
-                if (bottomZoneEntries[i].reversed)
-                    std::reverse(colors.data() + start, colors.data() + start + len);
+                hdrBottomCache.resize(static_cast<size_t>(4 * width * sampleHeight));
+                const auto bottomStartRow = height - sampleHeight;
+                for (int y = 0; y < sampleHeight; ++y)
+                    for (int x = 0; x < width; ++x)
+                    {
+                        const auto p = data[(bottomStartRow + y) * stridePixels + x];
+                        const auto idx = 4 * (y * width + x);
+                        hdrBottomCache[idx]     = static_cast<uchar>(((p >> 20) & 0x3ffu) >> 2);
+                        hdrBottomCache[idx + 1] = static_cast<uchar>(((p >> 10) & 0x3ffu) >> 2);
+                        hdrBottomCache[idx + 2] = static_cast<uchar>((p & 0x3ffu) >> 2);
+                        hdrBottomCache[idx + 3] = 0;
+                    }
+                for (auto i = 0u; i < bottomZoneEntries.size(); ++i)
+                {
+                    const auto start = std::min(bottomZoneEntries[i].range.from, bottomZoneEntries[i].range.to);
+                    const auto len = bottomZoneEntries[i].range.getLength();
+                    bottomSdrZoneProcs[i].processRegion(colors.data() + start, hdrBottomCache.data(), width, sampleHeight, width);
+                    if (bottomZoneEntries[i].reversed)
+                        std::reverse(colors.data() + start, colors.data() + start + len);
+                }
             }
-            for (auto i = 0u; i < leftZoneEntries.size(); ++i)
+            if (!leftZoneEntries.empty())
             {
-                const auto start = std::min(leftZoneEntries[i].range.from, leftZoneEntries[i].range.to);
-                const auto len = leftZoneEntries[i].range.getLength();
-                leftHdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, 0, stridePixels);
-                if (leftZoneEntries[i].reversed)
-                    std::reverse(colors.data() + start, colors.data() + start + len);
+                hdrLeftCache.resize(static_cast<size_t>(4 * sampleWidth * height));
+                for (int y = 0; y < height; ++y)
+                    for (int x = 0; x < sampleWidth; ++x)
+                    {
+                        const auto p = data[y * stridePixels + x];
+                        const auto idx = 4 * (y * sampleWidth + x);
+                        hdrLeftCache[idx]     = static_cast<uchar>(((p >> 20) & 0x3ffu) >> 2);
+                        hdrLeftCache[idx + 1] = static_cast<uchar>(((p >> 10) & 0x3ffu) >> 2);
+                        hdrLeftCache[idx + 2] = static_cast<uchar>((p & 0x3ffu) >> 2);
+                        hdrLeftCache[idx + 3] = 0;
+                    }
+                for (auto i = 0u; i < leftZoneEntries.size(); ++i)
+                {
+                    const auto start = std::min(leftZoneEntries[i].range.from, leftZoneEntries[i].range.to);
+                    const auto len = leftZoneEntries[i].range.getLength();
+                    leftSdrZoneProcs[i].processRegion(colors.data() + start, hdrLeftCache.data(), sampleWidth, height, 0, sampleWidth);
+                    if (leftZoneEntries[i].reversed)
+                        std::reverse(colors.data() + start, colors.data() + start + len);
+                }
             }
-            for (auto i = 0u; i < rightZoneEntries.size(); ++i)
+            if (!rightZoneEntries.empty())
             {
-                const auto start = std::min(rightZoneEntries[i].range.from, rightZoneEntries[i].range.to);
-                const auto len = rightZoneEntries[i].range.getLength();
-                rightHdrZoneProcs[i].processRegion(colors.data() + start, data, sampleWidth, height, width - sampleWidth, stridePixels);
-                if (rightZoneEntries[i].reversed)
-                    std::reverse(colors.data() + start, colors.data() + start + len);
+                hdrRightCache.resize(static_cast<size_t>(4 * sampleWidth * height));
+                const auto rightStartX = width - sampleWidth;
+                for (int y = 0; y < height; ++y)
+                    for (int x = 0; x < sampleWidth; ++x)
+                    {
+                        const auto p = data[y * stridePixels + (rightStartX + x)];
+                        const auto idx = 4 * (y * sampleWidth + x);
+                        hdrRightCache[idx]     = static_cast<uchar>(((p >> 20) & 0x3ffu) >> 2);
+                        hdrRightCache[idx + 1] = static_cast<uchar>(((p >> 10) & 0x3ffu) >> 2);
+                        hdrRightCache[idx + 2] = static_cast<uchar>((p & 0x3ffu) >> 2);
+                        hdrRightCache[idx + 3] = 0;
+                    }
+                for (auto i = 0u; i < rightZoneEntries.size(); ++i)
+                {
+                    const auto start = std::min(rightZoneEntries[i].range.from, rightZoneEntries[i].range.to);
+                    const auto len = rightZoneEntries[i].range.getLength();
+                    rightSdrZoneProcs[i].processRegion(colors.data() + start, hdrRightCache.data(), sampleWidth, height, 0, sampleWidth);
+                    if (rightZoneEntries[i].reversed)
+                        std::reverse(colors.data() + start, colors.data() + start + len);
+                }
             }
         }
 
@@ -243,10 +297,10 @@ private:
     std::vector<SdrVerticalRegionProcessor<CPP>>   leftSdrZoneProcs;
     std::vector<SdrVerticalRegionProcessor<CPP>>   rightSdrZoneProcs;
 
-    std::vector<HdrHorizontalRegionProcessor<CPP>> topHdrZoneProcs;
-    std::vector<HdrHorizontalRegionProcessor<CPP>> bottomHdrZoneProcs;
-    std::vector<HdrVerticalRegionProcessor<CPP>>   leftHdrZoneProcs;
-    std::vector<HdrVerticalRegionProcessor<CPP>>   rightHdrZoneProcs;
+    std::vector<uchar> hdrTopCache;
+    std::vector<uchar> hdrBottomCache;
+    std::vector<uchar> hdrLeftCache;
+    std::vector<uchar> hdrRightCache;
 
     std::vector<RGBColor> colors;
 };

--- a/ImageProcessor.h
+++ b/ImageProcessor.h
@@ -43,7 +43,7 @@ public:
                    LedRange bottomRange,
                    LedRange rightRange,
                    LedRange leftRange,
-                   std::vector<ZoneLedRange> zoneMappings,
+                   const std::vector<ZoneLedRange> &zoneMappings,
                    std::array<float, 3> colorFactors,
                    CPP colorPostProcessor,
                    QObject *eventReceiver)

--- a/LedPreviewWidget.cpp
+++ b/LedPreviewWidget.cpp
@@ -1,5 +1,7 @@
 //
 
+#include <algorithm>
+
 #include <QPainter>
 
 #include <ResourceManager.h>
@@ -61,6 +63,7 @@ std::vector<QColor> LedPreviewWidget::collectRegionColors(ScreenRegion region) c
                 const int absFrom = static_cast<int>(zone.start_idx) + part.from;
                 const int absTo   = static_cast<int>(zone.start_idx) + part.to;
 
+                const int segStart = static_cast<int>(result.size());
                 for (int i = absFrom; i < absTo && i < static_cast<int>(colors.size()); ++i)
                 {
                     const RGBColor c = colors[i];
@@ -70,6 +73,11 @@ std::vector<QColor> LedPreviewWidget::collectRegionColors(ScreenRegion region) c
                         static_cast<int>((c >> 16) & 0xFF)
                     );
                 }
+                // Processor stores result[0] = bottom/right of screen by default.
+                // reversed=true means std::reverse was applied → result[0] = top/left → correct draw order.
+                // reversed=false → result[0] = bottom/right → must reverse for screen-coordinate display.
+                if (!part.reversed)
+                    std::reverse(result.begin() + segStart, result.end());
             }
         }
     }

--- a/LedPreviewWidget.cpp
+++ b/LedPreviewWidget.cpp
@@ -1,0 +1,125 @@
+//
+
+#include <QPainter>
+
+#include <ResourceManager.h>
+#include <RGBController.h>
+
+#include "Settings.h"
+#include "LedPreviewWidget.h"
+
+LedPreviewWidget::LedPreviewWidget(ResourceManagerInterface *resourceManager, Settings &settings, QWidget *parent)
+    : QWidget{parent}
+    , resourceManager{resourceManager}
+    , settings{settings}
+{
+    setFixedWidth(320);
+    setFixedHeight(180); // updated on first frame to match display proportions
+}
+
+void LedPreviewWidget::updateFrame(const QImage &image)
+{
+    if (!image.isNull() && image.width() > 0)
+    {
+        const int h = 320 * image.height() / image.width();
+        if (h != height())
+            setFixedHeight(h);
+    }
+    currentFrame = image;
+    update();
+}
+
+void LedPreviewWidget::updateLedColors(const QString &location, std::vector<RGBColor> colors)
+{
+    deviceColors[location.toStdString()] = std::move(colors);
+    update();
+}
+
+std::vector<QColor> LedPreviewWidget::collectRegionColors(ScreenRegion region) const
+{
+    std::vector<QColor> result;
+
+    for (const auto *controller : resourceManager->GetRGBControllers())
+    {
+        if (!settings.isControllerSelected(controller->location))
+            continue;
+
+        const auto it = deviceColors.find(controller->location);
+        if (it == deviceColors.end())
+            continue;
+
+        const auto &colors = it->second;
+
+        for (const auto &zone : controller->zones)
+        {
+            const auto parts = settings.getZoneParts(controller->location, zone.name);
+            for (const auto &part : parts)
+            {
+                if (part.region != region)
+                    continue;
+
+                const int absFrom = static_cast<int>(zone.start_idx) + part.from;
+                const int absTo   = static_cast<int>(zone.start_idx) + part.to;
+
+                for (int i = absFrom; i < absTo && i < static_cast<int>(colors.size()); ++i)
+                {
+                    const RGBColor c = colors[i];
+                    result.emplace_back(
+                        static_cast<int>(c & 0xFF),
+                        static_cast<int>((c >> 8) & 0xFF),
+                        static_cast<int>((c >> 16) & 0xFF)
+                    );
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+void LedPreviewWidget::paintEvent(QPaintEvent *)
+{
+    QPainter painter{this};
+
+    const int w = width();
+    const int h = height();
+    const int e = EDGE;
+
+    painter.fillRect(rect(), Qt::black);
+
+    // Draw captured frame in the inner area
+    if (!currentFrame.isNull())
+    {
+        const QRect frameRect{e, e, w - 2 * e, h - 2 * e};
+        painter.drawImage(frameRect, currentFrame.scaled(frameRect.size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+    }
+
+    // Draw horizontal LED strip (top or bottom edge)
+    auto drawHStrip = [&](const std::vector<QColor> &colors, int x, int y, int stripW, int stripH) {
+        if (colors.empty()) return;
+        const int n = static_cast<int>(colors.size());
+        for (int i = 0; i < n; ++i)
+        {
+            const int rx = x + i * stripW / n;
+            const int rw = (i + 1) * stripW / n - i * stripW / n;
+            painter.fillRect(rx, y, rw, stripH, colors[i]);
+        }
+    };
+
+    // Draw vertical LED strip (left or right edge)
+    auto drawVStrip = [&](const std::vector<QColor> &colors, int x, int y, int stripW, int stripH) {
+        if (colors.empty()) return;
+        const int n = static_cast<int>(colors.size());
+        for (int i = 0; i < n; ++i)
+        {
+            const int ry = y + i * stripH / n;
+            const int rh = (i + 1) * stripH / n - i * stripH / n;
+            painter.fillRect(x, ry, stripW, rh, colors[i]);
+        }
+    };
+
+    drawHStrip(collectRegionColors(ScreenRegion::Top),    e,     0,     w - 2 * e, e);
+    drawHStrip(collectRegionColors(ScreenRegion::Bottom), e,     h - e, w - 2 * e, e);
+    drawVStrip(collectRegionColors(ScreenRegion::Left),   0,     e,     e, h - 2 * e);
+    drawVStrip(collectRegionColors(ScreenRegion::Right),  w - e, e,     e, h - 2 * e);
+}

--- a/LedPreviewWidget.cpp
+++ b/LedPreviewWidget.cpp
@@ -31,9 +31,9 @@ void LedPreviewWidget::updateFrame(const QImage &image)
     update();
 }
 
-void LedPreviewWidget::updateLedColors(const QString &location, std::vector<RGBColor> colors)
+void LedPreviewWidget::updateLedColors(const QString &location, const std::vector<RGBColor> &colors)
 {
-    deviceColors[location.toStdString()] = std::move(colors);
+    deviceColors[location.toStdString()] = colors;
     update();
 }
 

--- a/LedPreviewWidget.cpp
+++ b/LedPreviewWidget.cpp
@@ -52,32 +52,64 @@ std::vector<QColor> LedPreviewWidget::collectRegionColors(ScreenRegion region) c
 
         const auto &colors = it->second;
 
-        for (const auto &zone : controller->zones)
+        if (settings.getMappingMode(controller->location) == MappingMode::Standard)
         {
-            const auto parts = settings.getZoneParts(controller->location, zone.name);
-            for (const auto &part : parts)
+            LedRange range;
+            switch (region)
             {
-                if (part.region != region)
+                case ScreenRegion::Top:    range = settings.getTopRegion(controller->location);    break;
+                case ScreenRegion::Bottom: range = settings.getBottomRegion(controller->location); break;
+                case ScreenRegion::Left:   range = settings.getLeftRegion(controller->location);   break;
+                case ScreenRegion::Right:  range = settings.getRightRegion(controller->location);  break;
+                default: continue;
+            }
+
+            const int lo = std::min(range.from, range.to);
+            const int hi = std::max(range.from, range.to);
+            const int segStart = static_cast<int>(result.size());
+            for (int i = lo; i < hi && i < static_cast<int>(colors.size()); ++i)
+            {
+                const RGBColor c = colors[i];
+                result.emplace_back(
+                    static_cast<int>(c & 0xFF),
+                    static_cast<int>((c >> 8) & 0xFF),
+                    static_cast<int>((c >> 16) & 0xFF)
+                );
+            }
+            if (range.from > range.to)
+                std::reverse(result.begin() + segStart, result.end());
+        }
+        else
+        {
+            for (const auto &zone : controller->zones)
+            {
+                if (!settings.isZoneEnabled(controller->location, zone.name))
                     continue;
 
-                const int absFrom = static_cast<int>(zone.start_idx) + part.from;
-                const int absTo   = static_cast<int>(zone.start_idx) + part.to;
-
-                const int segStart = static_cast<int>(result.size());
-                for (int i = absFrom; i < absTo && i < static_cast<int>(colors.size()); ++i)
+                const auto parts = settings.getZoneParts(controller->location, zone.name);
+                for (const auto &part : parts)
                 {
-                    const RGBColor c = colors[i];
-                    result.emplace_back(
-                        static_cast<int>(c & 0xFF),
-                        static_cast<int>((c >> 8) & 0xFF),
-                        static_cast<int>((c >> 16) & 0xFF)
-                    );
+                    if (part.region != region)
+                        continue;
+
+                    const int absFrom = static_cast<int>(zone.start_idx) + part.from;
+                    const int absTo   = static_cast<int>(zone.start_idx) + part.to;
+                    const int lo      = std::min(absFrom, absTo);
+                    const int hi      = std::max(absFrom, absTo);
+
+                    const int segStart = static_cast<int>(result.size());
+                    for (int i = lo; i < hi && i < static_cast<int>(colors.size()); ++i)
+                    {
+                        const RGBColor c = colors[i];
+                        result.emplace_back(
+                            static_cast<int>(c & 0xFF),
+                            static_cast<int>((c >> 8) & 0xFF),
+                            static_cast<int>((c >> 16) & 0xFF)
+                        );
+                    }
+                    if (!part.reversed)
+                        std::reverse(result.begin() + segStart, result.end());
                 }
-                // Processor stores result[0] = bottom/right of screen by default.
-                // reversed=true means std::reverse was applied → result[0] = top/left → correct draw order.
-                // reversed=false → result[0] = bottom/right → must reverse for screen-coordinate display.
-                if (!part.reversed)
-                    std::reverse(result.begin() + segStart, result.end());
             }
         }
     }

--- a/LedPreviewWidget.h
+++ b/LedPreviewWidget.h
@@ -28,7 +28,7 @@ public:
 
 public slots:
     void updateFrame(const QImage &image);
-    void updateLedColors(const QString &location, std::vector<RGBColor> colors);
+    void updateLedColors(const QString &location, const std::vector<RGBColor> &colors);
 
 protected:
     void paintEvent(QPaintEvent *event) override;

--- a/LedPreviewWidget.h
+++ b/LedPreviewWidget.h
@@ -1,0 +1,48 @@
+//
+
+#ifndef OPENRGB_AMBIENT_LEDPREVIEWWIDGET_H
+#define OPENRGB_AMBIENT_LEDPREVIEWWIDGET_H
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+#include <QImage>
+#include <QWidget>
+
+#include <RGBController.h>
+
+#include "ZoneMapping.h"
+
+class ResourceManagerInterface;
+class Settings;
+class QPaintEvent;
+
+class LedPreviewWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    LedPreviewWidget(ResourceManagerInterface *resourceManager, Settings &settings, QWidget *parent = nullptr);
+    ~LedPreviewWidget() override = default;
+
+public slots:
+    void updateFrame(const QImage &image);
+    void updateLedColors(const QString &location, std::vector<RGBColor> colors);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    static constexpr int EDGE = 14; // px for each LED strip border
+
+    ResourceManagerInterface *resourceManager;
+    Settings &settings;
+
+    QImage currentFrame;
+    std::unordered_map<std::string, std::vector<RGBColor>> deviceColors;
+
+    [[nodiscard]] std::vector<QColor> collectRegionColors(ScreenRegion region) const;
+};
+
+#endif //OPENRGB_AMBIENT_LEDPREVIEWWIDGET_H

--- a/LedRange.h
+++ b/LedRange.h
@@ -9,8 +9,8 @@
 
 struct LedRange
 {
-    int from;
-    int to;
+    int from = 0;
+    int to   = 0;
 
     inline int getLength() const noexcept
     {

--- a/OpenRGBAmbientPlugin.cpp
+++ b/OpenRGBAmbientPlugin.cpp
@@ -242,13 +242,14 @@ void OpenRGBAmbientPlugin::processImage(const std::shared_ptr<ID3D11Texture2D> &
     D3D11_MAPPED_SUBRESOURCE mapped;
     context->Map(image.get(), 0, D3D11_MAP_READ, 0, &mapped);
 
+    // If width = 1920 and bytesPerPixel = 4, a tightly packed buffer would have RowPitch = 7680 bytes.
+    // But a GPU might align rows to 8192 bytes, so RowPitch = 8192. Then stridePixels = 8192 / 4 = 2048.
+    // To index pixel (x, y), you must use data[y * stridePixels + x], not data[y * width + x].
+    const int stridePixels = static_cast<int>(mapped.RowPitch) / 4;
+
     // When preview is enabled, process frames in real-time even if settings tab is visible (pauseCapture set).
     if (!pauseCapture || preview)
     {
-        // If width = 1920 and bytesPerPixel = 4, a tightly packed buffer would have RowPitch = 7680 bytes.
-        // But a GPU might align rows to 8192 bytes, so RowPitch = 8192. Then stridePixels = 8192 / 4 = 2048.
-        // To index pixel (x, y), you must use data[y * stridePixels + x], not data[y * width + x].
-        const int stridePixels = static_cast<int>(mapped.RowPitch) / 4;
         if (desc.Format == DXGI_FORMAT_R10G10B10A2_UNORM)
         {
             for (const auto &processor : processors)
@@ -265,10 +266,37 @@ void OpenRGBAmbientPlugin::processImage(const std::shared_ptr<ID3D11Texture2D> &
         }
     }
 
-    if (preview && desc.Format != DXGI_FORMAT_R10G10B10A2_UNORM)
+    if (preview)
     {
-        QImage previewImg{static_cast<const uchar *>(mapped.pData), static_cast<int>(desc.Width), static_cast<int>(desc.Height), static_cast<int>(mapped.RowPitch), QImage::Format_RGB32};
-        emit previewUpdated(previewImg.copy());
+        const int srcW = static_cast<int>(desc.Width);
+        const int srcH = static_cast<int>(desc.Height);
+        constexpr int dstW = 320;
+        const int dstH = srcW > 0 ? dstW * srcH / srcW : 180;
+
+        if (desc.Format == DXGI_FORMAT_R10G10B10A2_UNORM)
+        {
+            const auto *hdrData = static_cast<const std::uint32_t *>(mapped.pData);
+            QImage previewImg{dstW, dstH, QImage::Format_RGB32};
+            for (int y = 0; y < dstH; ++y)
+            {
+                const int srcY = y * srcH / dstH;
+                auto *line = reinterpret_cast<QRgb *>(previewImg.scanLine(y));
+                for (int x = 0; x < dstW; ++x)
+                {
+                    const int srcX = x * srcW / dstW;
+                    const std::uint32_t pixel = hdrData[srcY * stridePixels + srcX];
+                    line[x] = qRgb((pixel & 0x3ff) >> 2,
+                                   ((pixel >> 10) & 0x3ff) >> 2,
+                                   ((pixel >> 20) & 0x3ff) >> 2);
+                }
+            }
+            emit previewUpdated(previewImg);
+        }
+        else
+        {
+            QImage previewImg{static_cast<const uchar *>(mapped.pData), srcW, srcH, static_cast<int>(mapped.RowPitch), QImage::Format_RGB32};
+            emit previewUpdated(previewImg.copy());
+        }
     }
 
     context->Unmap(image.get(), 0);
@@ -287,9 +315,22 @@ void OpenRGBAmbientPlugin::processUpdate(const LedUpdateEvent &event)
     {
         const auto &colors = event.getColors();
 
-        const auto numColors = colors.size();
-        for (auto i = 0; i < numColors; ++i)
-            (*controller)->SetLED(i, colors[i]);
+        for (const auto &zone : (*controller)->zones)
+        {
+            if (!settings->isZoneEnabled(location, zone.name))
+                continue;
+
+            for (const auto &part : settings->getZoneParts(location, zone.name))
+            {
+                if (part.region == ScreenRegion::None)
+                    continue;
+
+                const int absFrom = static_cast<int>(zone.start_idx) + part.from;
+                const int absTo   = static_cast<int>(zone.start_idx) + part.to;
+                for (int i = absFrom; i < absTo && i < static_cast<int>(colors.size()); ++i)
+                    (*controller)->SetLED(i, colors[i]);
+            }
+        }
 
         (*controller)->UpdateLEDs();
 
@@ -303,6 +344,9 @@ std::unique_ptr<ImageProcessorBase> OpenRGBAmbientPlugin::createProcessor(RGBCon
     std::vector<ZoneLedRange> zoneMappings;
     for (const auto &zone : controller->zones)
     {
+        if (!settings->isZoneEnabled(controller->location, zone.name))
+            continue;
+
         const auto parts = settings->getZoneParts(controller->location, zone.name);
         for (const auto &part : parts)
         {

--- a/OpenRGBAmbientPlugin.cpp
+++ b/OpenRGBAmbientPlugin.cpp
@@ -77,7 +77,11 @@ void OpenRGBAmbientPlugin::Load(ResourceManagerInterface *resource_manager_ptr)
     resourceManager = resource_manager_ptr;
 
     settings = new Settings{QString::fromStdString((resourceManager->GetConfigurationDirectory() / "OpenRGBAmbientPlugin.ini").string()), this};
-    connect(settings, &Settings::settingsChanged, this, &OpenRGBAmbientPlugin::updateProcessors);
+    debounceTimer = new QTimer{this};
+    debounceTimer->setSingleShot(true);
+    debounceTimer->setInterval(150);
+    connect(debounceTimer, &QTimer::timeout, this, &OpenRGBAmbientPlugin::updateProcessors);
+    connect(settings, &Settings::settingsChanged, debounceTimer, qOverload<>(&QTimer::start));
 
     connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, &OpenRGBAmbientPlugin::turnOffLeds, Qt::DirectConnection);
 
@@ -315,20 +319,38 @@ void OpenRGBAmbientPlugin::processUpdate(const LedUpdateEvent &event)
     {
         const auto &colors = event.getColors();
 
-        for (const auto &zone : (*controller)->zones)
+        if (settings->getMappingMode(location) == MappingMode::Standard)
         {
-            if (!settings->isZoneEnabled(location, zone.name))
-                continue;
-
-            for (const auto &part : settings->getZoneParts(location, zone.name))
+            auto writeRange = [&](const LedRange &range) {
+                const int lo = std::min(range.from, range.to);
+                const int hi = std::max(range.from, range.to);
+                for (int i = lo; i < hi && i < static_cast<int>(colors.size()); ++i)
+                    (*controller)->SetLED(i, colors[i]);
+            };
+            writeRange(settings->getTopRegion(location));
+            writeRange(settings->getBottomRegion(location));
+            writeRange(settings->getLeftRegion(location));
+            writeRange(settings->getRightRegion(location));
+        }
+        else
+        {
+            for (const auto &zone : (*controller)->zones)
             {
-                if (part.region == ScreenRegion::None)
+                if (!settings->isZoneEnabled(location, zone.name))
                     continue;
 
-                const int absFrom = static_cast<int>(zone.start_idx) + part.from;
-                const int absTo   = static_cast<int>(zone.start_idx) + part.to;
-                for (int i = absFrom; i < absTo && i < static_cast<int>(colors.size()); ++i)
-                    (*controller)->SetLED(i, colors[i]);
+                for (const auto &part : settings->getZoneParts(location, zone.name))
+                {
+                    if (part.region == ScreenRegion::None)
+                        continue;
+
+                    const int absFrom = static_cast<int>(zone.start_idx) + part.from;
+                    const int absTo   = static_cast<int>(zone.start_idx) + part.to;
+                    const int lo      = std::min(absFrom, absTo);
+                    const int hi      = std::max(absFrom, absTo);
+                    for (int i = lo; i < hi && i < static_cast<int>(colors.size()); ++i)
+                        (*controller)->SetLED(i, colors[i]);
+                }
             }
         }
 
@@ -368,6 +390,7 @@ std::unique_ptr<ImageProcessorBase> OpenRGBAmbientPlugin::createProcessor(RGBCon
             std::move(zoneMappings),
             colorFactors,
             colorPostProcessor,
+            settings->getMappingMode(controller->location) == MappingMode::Zone,
             this
     );
 }

--- a/OpenRGBAmbientPlugin.cpp
+++ b/OpenRGBAmbientPlugin.cpp
@@ -11,6 +11,7 @@
 
 #include "ColorConversion.h"
 #include "LedUpdateEvent.h"
+#include "ZoneMapping.h"
 #include "ReleaseWrapper.h"
 #include "ScreenCapture.h"
 #include "SettingsTab.h"
@@ -104,6 +105,7 @@ QWidget *OpenRGBAmbientPlugin::GetWidget()
 {
     const auto ui = new SettingsTab{resourceManager, *settings};
     connect(this, &OpenRGBAmbientPlugin::previewUpdated, ui, &SettingsTab::updatePreview);
+    connect(this, &OpenRGBAmbientPlugin::ledColorsUpdated, ui, &SettingsTab::updateLedColors);
     connect(ui, &SettingsTab::previewChanged, this, &OpenRGBAmbientPlugin::setPreview);
     connect(ui, &SettingsTab::settingsVisibilityChanged, this, &OpenRGBAmbientPlugin::setPauseCapture);
 
@@ -168,8 +170,10 @@ void OpenRGBAmbientPlugin::updateProcessors()
 
 void OpenRGBAmbientPlugin::startCapture()
 {
+    const auto adapterIdx = static_cast<UINT>(settings->monitorAdapter());
+    const auto outputIdx  = settings->monitorOutput();
     captureThread = std::thread([=] {
-        ScreenCapture capture;
+        ScreenCapture capture{adapterIdx, outputIdx};
         Limiter limiter{60};
 
         while (!stopFlag.load())
@@ -288,18 +292,36 @@ void OpenRGBAmbientPlugin::processUpdate(const LedUpdateEvent &event)
             (*controller)->SetLED(i, colors[i]);
 
         (*controller)->UpdateLEDs();
+
+        emit ledColorsUpdated(QString::fromStdString(location), colors);
     }
 }
 
 template<ColorPostProcessor CPP>
 std::unique_ptr<ImageProcessorBase> OpenRGBAmbientPlugin::createProcessor(RGBController *controller, std::array<float, 3> colorFactors, CPP colorPostProcessor)
 {
+    std::vector<ZoneLedRange> zoneMappings;
+    for (const auto &zone : controller->zones)
+    {
+        const auto parts = settings->getZoneParts(controller->location, zone.name);
+        for (const auto &part : parts)
+        {
+            if (part.region == ScreenRegion::None)
+                continue;
+            const auto absFrom = static_cast<int>(zone.start_idx) + part.from;
+            const auto absTo   = static_cast<int>(zone.start_idx) + part.to;
+            zoneMappings.push_back({{absFrom, absTo}, part.region, part.reversed});
+        }
+    }
+
     return std::make_unique<ImageProcessor<CPP>>(
             controller->location,
+            static_cast<int>(controller->leds.size()),
             settings->getTopRegion(controller->location),
             settings->getBottomRegion(controller->location),
             settings->getRightRegion(controller->location),
             settings->getLeftRegion(controller->location),
+            std::move(zoneMappings),
             colorFactors,
             colorPostProcessor,
             this

--- a/OpenRGBAmbientPlugin.h
+++ b/OpenRGBAmbientPlugin.h
@@ -57,7 +57,7 @@ public slots:
 
 signals:
     void previewUpdated(const QImage &image);
-    void ledColorsUpdated(const QString &location, std::vector<RGBColor> colors);
+    void ledColorsUpdated(const QString &location, const std::vector<RGBColor> &colors);
 
 private:
     static const TCHAR *END_SESSION_WND_CLASS;

--- a/OpenRGBAmbientPlugin.h
+++ b/OpenRGBAmbientPlugin.h
@@ -14,6 +14,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QTimer>
 
 #include <OpenRGBPluginInterface.h>
 #include <RGBController.h>
@@ -68,6 +69,8 @@ private:
     std::atomic_bool stopFlag{false};
     std::atomic_bool preview{false};
     std::atomic_bool pauseCapture{false};
+
+    QTimer *debounceTimer = nullptr;
 
     std::vector<std::unique_ptr<ImageProcessorBase>> processors;
 

--- a/OpenRGBAmbientPlugin.h
+++ b/OpenRGBAmbientPlugin.h
@@ -13,8 +13,10 @@
 #include <d3d11.h>
 
 #include <QObject>
+#include <QString>
 
 #include <OpenRGBPluginInterface.h>
+#include <RGBController.h>
 
 #include "ImageProcessor.h"
 #include "Settings.h"
@@ -55,6 +57,7 @@ public slots:
 
 signals:
     void previewUpdated(const QImage &image);
+    void ledColorsUpdated(const QString &location, std::vector<RGBColor> colors);
 
 private:
     static const TCHAR *END_SESSION_WND_CLASS;

--- a/RegionsWidget.cpp
+++ b/RegionsWidget.cpp
@@ -5,11 +5,18 @@
 #include <algorithm>
 
 #include <QFormLayout>
+#include <QLabel>
+#include <QComboBox>
+#include <QCheckBox>
+#include <QHBoxLayout>
+#include <QSpinBox>
+#include <QPushButton>
 
 #include <ResourceManager.h>
 
 #include "RegionWidget.h"
 #include "Settings.h"
+#include "ZoneMapping.h"
 
 #include "RegionsWidget.h"
 
@@ -85,6 +92,13 @@ RegionsWidget::RegionsWidget(ResourceManagerInterface *resourceManager, Settings
     });
 
     layout->addRow("Left", left);
+
+    layout->addRow(new QLabel{"<b>Zone mapping</b>"});
+
+    zonesContainer = new QWidget{};
+    zonesLayout = new QFormLayout{zonesContainer};
+    zonesLayout->setContentsMargins(0, 0, 0, 0);
+    layout->addRow(zonesContainer);
 }
 
 void RegionsWidget::selectController(const QString &location)
@@ -103,6 +117,7 @@ void RegionsWidget::selectController(const QString &location)
         right->setConfiguration(0, 0, 0);
         left->setConfiguration(0, 0, 0);
 
+        rebuildZoneRows();
         return;
     }
 
@@ -117,6 +132,8 @@ void RegionsWidget::selectController(const QString &location)
     bottom->setConfiguration(max, bottomRange.from, bottomRange.to);
     right->setConfiguration(max, rightRange.from, rightRange.to);
     left->setConfiguration(max, leftRange.from, leftRange.to);
+
+    rebuildZoneRows();
 }
 
 void RegionsWidget::showCurrentLeds(int from, int to)
@@ -166,4 +183,136 @@ void RegionsWidget::clearCurrentLeds()
 void RegionsWidget::setPreview(bool enabled)
 {
     preview = enabled;
+}
+
+void RegionsWidget::rebuildZoneRows()
+{
+    while (zonesLayout->rowCount() > 0)
+        zonesLayout->removeRow(0);
+
+    if (currentLocation.empty())
+        return;
+
+    const auto &controllers = resourceManager->GetRGBControllers();
+    const auto controllerIt = std::ranges::find_if(controllers, [&](auto c) {
+        return c->location == currentLocation;
+    });
+
+    if (controllerIt == std::end(controllers))
+        return;
+
+    static const QStringList regionNames = {"None", "Top", "Bottom", "Left", "Right"};
+
+    const auto loc = currentLocation;
+
+    for (const auto &zone : (*controllerIt)->zones)
+    {
+        const auto zoneName  = zone.name;
+        const auto maxLeds   = static_cast<int>(zone.leds_count);
+        const auto segsCopy  = zone.segments;
+
+        // --- Zone header row ---
+        const auto headerWidget = new QWidget{};
+        const auto headerLayout = new QHBoxLayout{headerWidget};
+        headerLayout->setContentsMargins(0, 0, 0, 0);
+        headerLayout->addWidget(new QLabel{QString("<b>%1</b>").arg(QString::fromStdString(zoneName))});
+
+        if (!segsCopy.empty())
+        {
+            const auto loadBtn = new QPushButton{"Load segments"};
+            connect(loadBtn, &QPushButton::clicked, this, [=]() {
+                std::vector<ZonePart> parts;
+                for (const auto &seg : segsCopy)
+                    parts.push_back({static_cast<int>(seg.start_idx),
+                                     static_cast<int>(seg.start_idx + seg.leds_count),
+                                     ScreenRegion::None, false});
+                this->settings.setZoneParts(loc, zoneName, parts);
+                QMetaObject::invokeMethod(this, &RegionsWidget::rebuildZoneRows, Qt::QueuedConnection);
+            });
+            headerLayout->addWidget(loadBtn);
+        }
+
+        const auto addBtn = new QPushButton{"+"};
+        addBtn->setMaximumWidth(28);
+        connect(addBtn, &QPushButton::clicked, this, [=]() {
+            auto parts = this->settings.getZoneParts(loc, zoneName);
+            parts.push_back({0, maxLeds, ScreenRegion::None, false});
+            this->settings.setZoneParts(loc, zoneName, parts);
+            QMetaObject::invokeMethod(this, &RegionsWidget::rebuildZoneRows, Qt::QueuedConnection);
+        });
+        headerLayout->addWidget(addBtn);
+        headerLayout->addStretch();
+
+        zonesLayout->addRow(headerWidget);
+
+        // --- One row per part ---
+        const auto parts = settings.getZoneParts(loc, zoneName);
+        for (int partIdx = 0; partIdx < static_cast<int>(parts.size()); ++partIdx)
+        {
+            const auto &part = parts[partIdx];
+
+            const auto fromSpin = new QSpinBox{};
+            fromSpin->setRange(0, maxLeds);
+            fromSpin->setValue(part.from);
+            fromSpin->setPrefix("from ");
+
+            const auto toSpin = new QSpinBox{};
+            toSpin->setRange(0, maxLeds);
+            toSpin->setValue(part.to);
+            toSpin->setPrefix("to ");
+
+            const auto regionCombo = new QComboBox{};
+            for (int i = 0; i < regionNames.size(); ++i)
+                regionCombo->addItem(regionNames[i], i);
+            regionCombo->setCurrentIndex(static_cast<int>(part.region));
+
+            const auto reversedCheck = new QCheckBox{"Rev"};
+            reversedCheck->setChecked(part.reversed);
+            reversedCheck->setEnabled(part.region != ScreenRegion::None);
+
+            const auto removeBtn = new QPushButton{"×"};
+            removeBtn->setMaximumWidth(25);
+
+            // Save current values of this part back to settings (no rebuild)
+            auto savePart = [=]() {
+                auto current = this->settings.getZoneParts(loc, zoneName);
+                if (partIdx < static_cast<int>(current.size()))
+                {
+                    current[partIdx] = {
+                        fromSpin->value(),
+                        toSpin->value(),
+                        static_cast<ScreenRegion>(regionCombo->currentData().toInt()),
+                        reversedCheck->isChecked()
+                    };
+                    this->settings.setZoneParts(loc, zoneName, current);
+                }
+            };
+
+            connect(fromSpin,     QOverload<int>::of(&QSpinBox::valueChanged),  this, savePart);
+            connect(toSpin,       QOverload<int>::of(&QSpinBox::valueChanged),  this, savePart);
+            connect(regionCombo,  QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=](int idx) {
+                reversedCheck->setEnabled(static_cast<ScreenRegion>(idx) != ScreenRegion::None);
+                savePart();
+            });
+            connect(reversedCheck, &QCheckBox::toggled, this, savePart);
+            connect(removeBtn, &QPushButton::clicked, this, [=]() {
+                auto current = this->settings.getZoneParts(loc, zoneName);
+                if (partIdx < static_cast<int>(current.size()))
+                    current.erase(current.begin() + partIdx);
+                this->settings.setZoneParts(loc, zoneName, current);
+                QMetaObject::invokeMethod(this, &RegionsWidget::rebuildZoneRows, Qt::QueuedConnection);
+            });
+
+            const auto partWidget = new QWidget{};
+            const auto partLayout = new QHBoxLayout{partWidget};
+            partLayout->setContentsMargins(16, 0, 0, 0);
+            partLayout->addWidget(fromSpin);
+            partLayout->addWidget(toSpin);
+            partLayout->addWidget(regionCombo);
+            partLayout->addWidget(reversedCheck);
+            partLayout->addWidget(removeBtn);
+
+            zonesLayout->addRow(partWidget);
+        }
+    }
 }

--- a/RegionsWidget.cpp
+++ b/RegionsWidget.cpp
@@ -9,6 +9,8 @@
 #include <QComboBox>
 #include <QCheckBox>
 #include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QRadioButton>
 #include <QSpinBox>
 #include <QPushButton>
 
@@ -27,7 +29,22 @@ RegionsWidget::RegionsWidget(ResourceManagerInterface *resourceManager, Settings
     , resourceManager{resourceManager}
     , settings{settings}
 {
-    const auto layout = new QFormLayout{this};
+    const auto mainLayout = new QVBoxLayout{this};
+    mainLayout->setContentsMargins(0, 0, 0, 0);
+
+    // Mapping mode selector
+    const auto radioLayout = new QHBoxLayout{};
+    standardRadio = new QRadioButton{"Standard mapping"};
+    zoneRadio     = new QRadioButton{"Zone mapping"};
+    standardRadio->setChecked(true);
+    radioLayout->addWidget(standardRadio);
+    radioLayout->addWidget(zoneRadio);
+    radioLayout->addStretch();
+    mainLayout->addLayout(radioLayout);
+
+    // Standard mapping container
+    standardContainer = new QWidget{};
+    const auto standardLayout = new QFormLayout{standardContainer};
 
     top = new RegionWidget{};
     connect(top, &RegionWidget::regionChanged, this, [=](auto from, auto to) {
@@ -42,8 +59,7 @@ RegionsWidget::RegionsWidget(ResourceManagerInterface *resourceManager, Settings
         if (!preview)
             clearCurrentLeds();
     });
-
-    layout->addRow("Top", top);
+    standardLayout->addRow("Top", top);
 
     bottom = new RegionWidget{};
     connect(bottom, &RegionWidget::regionChanged, this, [=](auto from, auto to) {
@@ -58,8 +74,7 @@ RegionsWidget::RegionsWidget(ResourceManagerInterface *resourceManager, Settings
         if (!preview)
             clearCurrentLeds();
     });
-
-    layout->addRow("Bottom", bottom);
+    standardLayout->addRow("Bottom", bottom);
 
     right = new RegionWidget{};
     connect(right, &RegionWidget::regionChanged, this, [=](auto from, auto to) {
@@ -74,8 +89,7 @@ RegionsWidget::RegionsWidget(ResourceManagerInterface *resourceManager, Settings
         if (!preview)
             clearCurrentLeds();
     });
-
-    layout->addRow("Right", right);
+    standardLayout->addRow("Right", right);
 
     left = new RegionWidget{};
     connect(left, &RegionWidget::regionChanged, this, [=](auto from, auto to) {
@@ -90,15 +104,30 @@ RegionsWidget::RegionsWidget(ResourceManagerInterface *resourceManager, Settings
         if (!preview)
             clearCurrentLeds();
     });
+    standardLayout->addRow("Left", left);
 
-    layout->addRow("Left", left);
+    mainLayout->addWidget(standardContainer);
 
-    layout->addRow(new QLabel{"<b>Zone mapping</b>"});
+    // Zone mapping container
+    zoneContainer = new QWidget{};
+    const auto zoneLayout = new QVBoxLayout{zoneContainer};
+    zoneLayout->setContentsMargins(0, 0, 0, 0);
 
     zonesContainer = new QWidget{};
     zonesLayout = new QFormLayout{zonesContainer};
     zonesLayout->setContentsMargins(0, 0, 0, 0);
-    layout->addRow(zonesContainer);
+    zoneLayout->addWidget(zonesContainer);
+
+    zoneContainer->setVisible(false);
+    mainLayout->addWidget(zoneContainer);
+
+    // Toggle visibility and persist mode on radio button change
+    connect(standardRadio, &QRadioButton::toggled, this, [this](bool checked) {
+        standardContainer->setVisible(checked);
+        zoneContainer->setVisible(!checked);
+        if (!currentLocation.empty())
+            this->settings.setMappingMode(currentLocation, checked ? MappingMode::Standard : MappingMode::Zone);
+    });
 }
 
 void RegionsWidget::selectController(const QString &location)
@@ -109,6 +138,17 @@ void RegionsWidget::selectController(const QString &location)
     const auto controller = std::find_if(std::begin(controllers), std::end(controllers), [&](auto controller) {
         return controller->location == currentLocation;
     });
+
+    // Restore mapping mode for this controller without triggering a settings write
+    {
+        const QSignalBlocker b1{standardRadio};
+        const QSignalBlocker b2{zoneRadio};
+        const bool isZone = settings.getMappingMode(currentLocation) == MappingMode::Zone;
+        zoneRadio->setChecked(isZone);
+        standardRadio->setChecked(!isZone);
+        standardContainer->setVisible(!isZone);
+        zoneContainer->setVisible(isZone);
+    }
 
     if (controller == std::end(controllers))
     {
@@ -212,10 +252,21 @@ void RegionsWidget::rebuildZoneRows()
         const auto segsCopy  = zone.segments;
 
         // --- Zone header row ---
+        const auto zoneEnabled = settings.isZoneEnabled(loc, zoneName);
+
         const auto headerWidget = new QWidget{};
         const auto headerLayout = new QHBoxLayout{headerWidget};
         headerLayout->setContentsMargins(0, 0, 0, 0);
-        headerLayout->addWidget(new QLabel{QString("<b>%1</b>").arg(QString::fromStdString(zoneName))});
+
+        const auto enabledCheck = new QCheckBox{};
+        enabledCheck->setChecked(zoneEnabled);
+        headerLayout->addWidget(enabledCheck);
+
+        // Controls after the checkbox — greyed out when zone is disabled
+        const auto zoneControlsWidget = new QWidget{};
+        const auto zoneControlsLayout = new QHBoxLayout{zoneControlsWidget};
+        zoneControlsLayout->setContentsMargins(0, 0, 0, 0);
+        zoneControlsLayout->addWidget(new QLabel{QString("<b>%1</b>").arg(QString::fromStdString(zoneName))});
 
         if (!segsCopy.empty())
         {
@@ -229,7 +280,7 @@ void RegionsWidget::rebuildZoneRows()
                 this->settings.setZoneParts(loc, zoneName, parts);
                 QMetaObject::invokeMethod(this, &RegionsWidget::rebuildZoneRows, Qt::QueuedConnection);
             });
-            headerLayout->addWidget(loadBtn);
+            zoneControlsLayout->addWidget(loadBtn);
         }
 
         const auto addBtn = new QPushButton{"+"};
@@ -240,10 +291,25 @@ void RegionsWidget::rebuildZoneRows()
             this->settings.setZoneParts(loc, zoneName, parts);
             QMetaObject::invokeMethod(this, &RegionsWidget::rebuildZoneRows, Qt::QueuedConnection);
         });
-        headerLayout->addWidget(addBtn);
-        headerLayout->addStretch();
+        zoneControlsLayout->addWidget(addBtn);
+        zoneControlsLayout->addStretch();
+
+        zoneControlsWidget->setEnabled(zoneEnabled);
+        headerLayout->addWidget(zoneControlsWidget);
 
         zonesLayout->addRow(headerWidget);
+
+        // --- Part rows container — greyed out when zone is disabled ---
+        const auto partsContainer = new QWidget{};
+        const auto partsLayout    = new QVBoxLayout{partsContainer};
+        partsLayout->setContentsMargins(0, 0, 0, 0);
+        partsContainer->setEnabled(zoneEnabled);
+
+        connect(enabledCheck, &QCheckBox::toggled, this, [=](bool checked) {
+            this->settings.setZoneEnabled(loc, zoneName, checked);
+            zoneControlsWidget->setEnabled(checked);
+            partsContainer->setEnabled(checked);
+        });
 
         // --- One row per part ---
         const auto parts = settings.getZoneParts(loc, zoneName);
@@ -266,7 +332,7 @@ void RegionsWidget::rebuildZoneRows()
                 regionCombo->addItem(regionNames[i], i);
             regionCombo->setCurrentIndex(static_cast<int>(part.region));
 
-            const auto reversedCheck = new QCheckBox{"Rev"};
+            const auto reversedCheck = new QCheckBox{"Reverse"};
             reversedCheck->setChecked(part.reversed);
             reversedCheck->setEnabled(part.region != ScreenRegion::None);
 
@@ -312,7 +378,9 @@ void RegionsWidget::rebuildZoneRows()
             partLayout->addWidget(reversedCheck);
             partLayout->addWidget(removeBtn);
 
-            zonesLayout->addRow(partWidget);
+            partsLayout->addWidget(partWidget);
         }
+
+        zonesLayout->addRow(partsContainer);
     }
 }

--- a/RegionsWidget.h
+++ b/RegionsWidget.h
@@ -9,6 +9,7 @@
 
 #include <QWidget>
 
+class QFormLayout;
 class ResourceManagerInterface;
 class RegionWidget;
 class Settings;
@@ -38,8 +39,12 @@ private:
     std::string currentLocation;
     bool preview = false;
 
+    QWidget     *zonesContainer = nullptr;
+    QFormLayout *zonesLayout    = nullptr;
+
     void showCurrentLeds(int from, int to);
     void clearCurrentLeds();
+    void rebuildZoneRows();
 };
 
 #endif //OPENRGB_AMBIENT_REGIONSWIDGET_H

--- a/RegionsWidget.h
+++ b/RegionsWidget.h
@@ -10,6 +10,7 @@
 #include <QWidget>
 
 class QFormLayout;
+class QRadioButton;
 class ResourceManagerInterface;
 class RegionWidget;
 class Settings;
@@ -39,8 +40,12 @@ private:
     std::string currentLocation;
     bool preview = false;
 
-    QWidget     *zonesContainer = nullptr;
-    QFormLayout *zonesLayout    = nullptr;
+    QRadioButton *standardRadio     = nullptr;
+    QRadioButton *zoneRadio         = nullptr;
+    QWidget     *standardContainer = nullptr;
+    QWidget     *zoneContainer     = nullptr;
+    QWidget     *zonesContainer    = nullptr;
+    QFormLayout *zonesLayout       = nullptr;
 
     void showCurrentLeds(int from, int to);
     void clearCurrentLeds();

--- a/ScreenCapture.cpp
+++ b/ScreenCapture.cpp
@@ -8,7 +8,45 @@
 
 #include "ScreenCapture.h"
 
-ScreenCapture::ScreenCapture()
+std::vector<ScreenCapture::MonitorInfo> ScreenCapture::enumerateMonitors()
+{
+    std::vector<MonitorInfo> result;
+
+    IDXGIFactory1 *pFactory = nullptr;
+    if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1), reinterpret_cast<void **>(&pFactory))))
+        return result;
+    const auto factory = releasing(pFactory);
+
+    IDXGIAdapter1 *pAdapter = nullptr;
+    for (UINT adapterIdx = 0; factory->EnumAdapters1(adapterIdx, &pAdapter) == S_OK; ++adapterIdx)
+    {
+        const auto adapter = releasing(pAdapter);
+
+        IDXGIOutput *pOutput = nullptr;
+        for (int outputIdx = 0; adapter->EnumOutputs(static_cast<UINT>(outputIdx), &pOutput) == S_OK; ++outputIdx)
+        {
+            const auto output = releasing(pOutput);
+
+            DXGI_OUTPUT_DESC desc;
+            output->GetDesc(&desc);
+
+            const int width  = desc.DesktopCoordinates.right  - desc.DesktopCoordinates.left;
+            const int height = desc.DesktopCoordinates.bottom - desc.DesktopCoordinates.top;
+
+            // DeviceName is always ASCII (e.g. "\\.\DISPLAY1")
+            const std::wstring wname{desc.DeviceName};
+            const std::string  name{wname.begin(), wname.end()};
+
+            result.push_back({name + " (" + std::to_string(width) + "x" + std::to_string(height) + ")",
+                              adapterIdx, outputIdx});
+        }
+    }
+    return result;
+}
+
+ScreenCapture::ScreenCapture(UINT adapterIndex, int outputIndex)
+    : adapterIndex{adapterIndex}
+    , outputIndex{outputIndex}
 {
     initAdapter();
     initOutput();
@@ -16,7 +54,7 @@ ScreenCapture::ScreenCapture()
     initDuplicator();
 }
 
-void ScreenCapture::initAdapter(UINT index)
+void ScreenCapture::initAdapter()
 {
     IDXGIFactory1 *pFactory = nullptr;
 
@@ -32,7 +70,7 @@ void ScreenCapture::initAdapter(UINT index)
         if (FAILED(pAdapter->GetDesc(&desc)))
             throw std::runtime_error{"Failed to retrieve description of adapter."};
 
-        if (i == index)
+        if (i == adapterIndex)
         {
             adapter = releasing(pAdapter);
             factory = releasing(pFactory);
@@ -46,11 +84,12 @@ void ScreenCapture::initAdapter(UINT index)
     }
 }
 
-void ScreenCapture::initOutput(size_t index)
+void ScreenCapture::initOutput()
 {
     auto outputs = enumerateVideoOutputs();
-    if (index < outputs.size())
-        adapterOutput = std::move(outputs[index]);
+    const auto idx = static_cast<size_t>(outputIndex);
+    if (idx < outputs.size())
+        adapterOutput = std::move(outputs[idx]);
 }
 
 std::vector<std::shared_ptr<IDXGIOutput>> ScreenCapture::enumerateVideoOutputs()

--- a/ScreenCapture.h
+++ b/ScreenCapture.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <memory>
+#include <string>
 
 #include <windows.h>
 #include <dxgi1_5.h>
@@ -16,13 +17,25 @@
 class ScreenCapture final
 {
 public:
-    ScreenCapture();
+    struct MonitorInfo
+    {
+        std::string displayName; // e.g. "\\.\DISPLAY1 (1920x1080)"
+        UINT        adapterIndex;
+        int         outputIndex;
+    };
+
+    static std::vector<MonitorInfo> enumerateMonitors();
+
+    explicit ScreenCapture(UINT adapterIndex = 0, int outputIndex = 0);
 
     bool grabContent();
 
     [[nodiscard]] std::shared_ptr<ID3D11Texture2D> getScreen() const;
 
 private:
+    UINT adapterIndex;
+    int  outputIndex;
+
     std::shared_ptr<IDXGIFactory1> factory;
     std::shared_ptr<IDXGIAdapter1> adapter;
     std::shared_ptr<IDXGIOutput> adapterOutput;
@@ -32,8 +45,8 @@ private:
     std::shared_ptr<IDXGIOutput5> duplicatorOutput;
     std::shared_ptr<ID3D11Texture2D> image;
 
-    void initAdapter(UINT index = 0);
-    void initOutput(size_t index = 0);
+    void initAdapter();
+    void initOutput();
     void initDevice();
     bool initDuplicator();
 

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -18,6 +18,7 @@ QString Settings::BOTTOM_SUFFIX = "_Bottom"; // NOLINT(cert-err58-cpp)
 QString Settings::LEFT_SUFFIX = "_Left"; // NOLINT(cert-err58-cpp)
 QString Settings::RIGHT_SUFFIX = "_Right"; // NOLINT(cert-err58-cpp)
 QString Settings::ZONE_MAPPINGS_KEY   = "ZoneMappings"; // NOLINT(cert-err58-cpp)
+QString Settings::DISABLED_ZONES_KEY  = "DisabledZones"; // NOLINT(cert-err58-cpp)
 QString Settings::MONITOR_ADAPTER_KEY = "MonitorAdapter"; // NOLINT(cert-err58-cpp)
 QString Settings::MONITOR_OUTPUT_KEY  = "MonitorOutput"; // NOLINT(cert-err58-cpp)
 
@@ -36,6 +37,10 @@ Settings::Settings(const QString &file, QObject *parent)
 
     fillZoneParts(zoneParts, settings.value(ZONE_MAPPINGS_KEY).toHash());
 
+    const auto disabledList = settings.value(DISABLED_ZONES_KEY).toStringList();
+    for (const auto &key : disabledList)
+        disabledZones.insert(key.toStdString());
+
     coolWhiteCompensation = settings.value(COOL_WHITE_COMPENSATION_KEY, true).toBool();
     colorTemperatureIndex = std::clamp(
             settings.value(COLOR_TEMPERATURE_KEY, colorTemperatureIndex).toInt(),
@@ -52,6 +57,30 @@ Settings::Settings(const QString &file, QObject *parent)
 
 bool Settings::isControllerSelected(const std::string &location) const {
     return selectedControllers.find(location) != std::end(selectedControllers);
+}
+
+bool Settings::isZoneEnabled(const std::string &location, const std::string &zoneName) const
+{
+    return disabledZones.find(location + "|" + zoneName) == std::end(disabledZones);
+}
+
+void Settings::setZoneEnabled(const std::string &location, const std::string &zoneName, bool enabled)
+{
+    const auto key = location + "|" + zoneName;
+    if (enabled)
+        disabledZones.erase(key);
+    else
+        disabledZones.insert(key);
+    syncDisabledZones();
+}
+
+void Settings::syncDisabledZones()
+{
+    QStringList value;
+    for (const auto &key : disabledZones)
+        value.append(QString::fromStdString(key));
+    settings.setValue(DISABLED_ZONES_KEY, value);
+    emit settingsChanged();
 }
 
 void Settings::selectController(const std::string &location) {

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -17,6 +17,9 @@ QString Settings::TOP_SUFFIX = "_Top"; // NOLINT(cert-err58-cpp)
 QString Settings::BOTTOM_SUFFIX = "_Bottom"; // NOLINT(cert-err58-cpp)
 QString Settings::LEFT_SUFFIX = "_Left"; // NOLINT(cert-err58-cpp)
 QString Settings::RIGHT_SUFFIX = "_Right"; // NOLINT(cert-err58-cpp)
+QString Settings::ZONE_MAPPINGS_KEY   = "ZoneMappings"; // NOLINT(cert-err58-cpp)
+QString Settings::MONITOR_ADAPTER_KEY = "MonitorAdapter"; // NOLINT(cert-err58-cpp)
+QString Settings::MONITOR_OUTPUT_KEY  = "MonitorOutput"; // NOLINT(cert-err58-cpp)
 
 Settings::Settings(const QString &file, QObject *parent)
     : QObject{parent}
@@ -31,6 +34,8 @@ Settings::Settings(const QString &file, QObject *parent)
     fillRegions(leftRegions, settings.value(CONTROLLER_REGIONS_KEY + LEFT_SUFFIX).toHash());
     fillRegions(rightRegions, settings.value(CONTROLLER_REGIONS_KEY + RIGHT_SUFFIX).toHash());
 
+    fillZoneParts(zoneParts, settings.value(ZONE_MAPPINGS_KEY).toHash());
+
     coolWhiteCompensation = settings.value(COOL_WHITE_COMPENSATION_KEY, true).toBool();
     colorTemperatureIndex = std::clamp(
             settings.value(COLOR_TEMPERATURE_KEY, colorTemperatureIndex).toInt(),
@@ -40,6 +45,9 @@ Settings::Settings(const QString &file, QObject *parent)
 
     smoothing = settings.value(SMOOTHING_KEY, false).toBool();
     smoothingWeight = settings.value(SMOOTHING_WEIGHT_KEY, 0.5).toFloat();
+
+    monitorAdapterIndex = settings.value(MONITOR_ADAPTER_KEY, 0).toInt();
+    monitorOutputIndex  = settings.value(MONITOR_OUTPUT_KEY,  0).toInt();
 }
 
 bool Settings::isControllerSelected(const std::string &location) const {
@@ -120,6 +128,75 @@ void Settings::syncRegions(const RegionMap &map, const QString &key)
     settings.setValue(key, data);
 
     emit settingsChanged();
+}
+
+int Settings::monitorAdapter() const noexcept { return monitorAdapterIndex; }
+int Settings::monitorOutput()  const noexcept { return monitorOutputIndex; }
+
+void Settings::setMonitorAdapter(int index)
+{
+    monitorAdapterIndex = index;
+    settings.setValue(MONITOR_ADAPTER_KEY, monitorAdapterIndex);
+    emit settingsChanged();
+}
+
+void Settings::setMonitorOutput(int index)
+{
+    monitorOutputIndex = index;
+    settings.setValue(MONITOR_OUTPUT_KEY, monitorOutputIndex);
+    emit settingsChanged();
+}
+
+std::vector<ZonePart> Settings::getZoneParts(const std::string &location, const std::string &zoneName) const
+{
+    const auto key = location + "|" + zoneName;
+    const auto it = zoneParts.find(key);
+    return (it != std::end(zoneParts)) ? it->second : std::vector<ZonePart>{};
+}
+
+void Settings::setZoneParts(const std::string &location, const std::string &zoneName, std::vector<ZonePart> parts)
+{
+    zoneParts[location + "|" + zoneName] = std::move(parts);
+    syncZoneMappings();
+}
+
+void Settings::syncZoneMappings()
+{
+    QVariantHash data;
+    for (const auto &entry : zoneParts)
+    {
+        QVariantList partsList;
+        for (const auto &p : entry.second)
+            partsList.append(QVariant{QVariantList{p.from, p.to, static_cast<int>(p.region), p.reversed}});
+        data[QString::fromStdString(entry.first)] = partsList;
+    }
+
+    settings.setValue(ZONE_MAPPINGS_KEY, data);
+
+    emit settingsChanged();
+}
+
+void Settings::fillZoneParts(ZonePartsMap &map, const QVariantHash &data)
+{
+    QHashIterator i{data};
+    while (i.hasNext())
+    {
+        i.next();
+        std::vector<ZonePart> parts;
+        for (const auto &item : i.value().toList())
+        {
+            const auto entry = item.toList();
+            if (entry.size() < 4)
+                continue;
+            ZonePart p;
+            p.from     = entry[0].toInt();
+            p.to       = entry[1].toInt();
+            p.region   = static_cast<ScreenRegion>(entry[2].toInt());
+            p.reversed = entry[3].toBool();
+            parts.push_back(p);
+        }
+        map[i.key().toStdString()] = std::move(parts);
+    }
 }
 
 void Settings::fillRegions(RegionMap &map, const QVariantHash &data)

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -18,7 +18,8 @@ QString Settings::BOTTOM_SUFFIX = "_Bottom"; // NOLINT(cert-err58-cpp)
 QString Settings::LEFT_SUFFIX = "_Left"; // NOLINT(cert-err58-cpp)
 QString Settings::RIGHT_SUFFIX = "_Right"; // NOLINT(cert-err58-cpp)
 QString Settings::ZONE_MAPPINGS_KEY   = "ZoneMappings"; // NOLINT(cert-err58-cpp)
-QString Settings::DISABLED_ZONES_KEY  = "DisabledZones"; // NOLINT(cert-err58-cpp)
+QString Settings::DISABLED_ZONES_KEY         = "DisabledZones";        // NOLINT(cert-err58-cpp)
+QString Settings::ZONE_MAPPING_LOCATIONS_KEY = "ZoneMappingLocations"; // NOLINT(cert-err58-cpp)
 QString Settings::MONITOR_ADAPTER_KEY = "MonitorAdapter"; // NOLINT(cert-err58-cpp)
 QString Settings::MONITOR_OUTPUT_KEY  = "MonitorOutput"; // NOLINT(cert-err58-cpp)
 
@@ -40,6 +41,10 @@ Settings::Settings(const QString &file, QObject *parent)
     const auto disabledList = settings.value(DISABLED_ZONES_KEY).toStringList();
     for (const auto &key : disabledList)
         disabledZones.insert(key.toStdString());
+
+    const auto zoneModeList = settings.value(ZONE_MAPPING_LOCATIONS_KEY).toStringList();
+    for (const auto &loc : zoneModeList)
+        zoneMappingLocations.insert(loc.toStdString());
 
     coolWhiteCompensation = settings.value(COOL_WHITE_COMPENSATION_KEY, true).toBool();
     colorTemperatureIndex = std::clamp(
@@ -72,6 +77,29 @@ void Settings::setZoneEnabled(const std::string &location, const std::string &zo
     else
         disabledZones.insert(key);
     syncDisabledZones();
+}
+
+MappingMode Settings::getMappingMode(const std::string &location) const
+{
+    return zoneMappingLocations.count(location) ? MappingMode::Zone : MappingMode::Standard;
+}
+
+void Settings::setMappingMode(const std::string &location, MappingMode mode)
+{
+    if (mode == MappingMode::Zone)
+        zoneMappingLocations.insert(location);
+    else
+        zoneMappingLocations.erase(location);
+    syncMappingModes();
+}
+
+void Settings::syncMappingModes()
+{
+    QStringList value;
+    for (const auto &loc : zoneMappingLocations)
+        value.append(QString::fromStdString(loc));
+    settings.setValue(ZONE_MAPPING_LOCATIONS_KEY, value);
+    emit settingsChanged();
 }
 
 void Settings::syncDisabledZones()

--- a/Settings.h
+++ b/Settings.h
@@ -31,6 +31,9 @@ public:
     void selectController(const std::string &location);
     void unselectController(const std::string &location);
 
+    [[nodiscard]] bool isZoneEnabled(const std::string &location, const std::string &zoneName) const;
+    void setZoneEnabled(const std::string &location, const std::string &zoneName, bool enabled);
+
     [[nodiscard]] LedRange getTopRegion(const std::string &location) const;
     [[nodiscard]] LedRange getBottomRegion(const std::string &location) const;
     [[nodiscard]] LedRange getRightRegion(const std::string &location) const;
@@ -78,6 +81,7 @@ private:
     static QString RIGHT_SUFFIX;
 
     static QString ZONE_MAPPINGS_KEY;
+    static QString DISABLED_ZONES_KEY;
     static QString MONITOR_ADAPTER_KEY;
     static QString MONITOR_OUTPUT_KEY;
 
@@ -87,6 +91,7 @@ private:
     QSettings settings;
 
     std::unordered_set<std::string> selectedControllers;
+    std::unordered_set<std::string> disabledZones; // key: "location|zoneName"
 
     RegionMap topRegions;
     RegionMap bottomRegions;
@@ -106,6 +111,7 @@ private:
     float smoothingWeight = 0.5;
 
     void syncSelectedControllers();
+    void syncDisabledZones();
     void syncRegions(const RegionMap &map, const QString &key);
     void syncZoneMappings();
 

--- a/Settings.h
+++ b/Settings.h
@@ -8,11 +8,13 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <string>
+#include <vector>
 
 #include <QSettings>
 #include <QObject>
 
 #include "LedRange.h"
+#include "ZoneMapping.h"
 
 class ResourceManager;
 class QString;
@@ -38,6 +40,14 @@ public:
     void setBottomRegion(const std::string &location, LedRange range);
     void setRightRegion(const std::string &location, LedRange range);
     void setLeftRegion(const std::string &location, LedRange range);
+
+    [[nodiscard]] std::vector<ZonePart> getZoneParts(const std::string &location, const std::string &zoneName) const;
+    void setZoneParts(const std::string &location, const std::string &zoneName, std::vector<ZonePart> parts);
+
+    [[nodiscard]] int monitorAdapter() const noexcept;
+    [[nodiscard]] int monitorOutput() const noexcept;
+    void setMonitorAdapter(int index);
+    void setMonitorOutput(int index);
 
     [[nodiscard]] bool compensateCoolWhite() const noexcept;
     void setCoolWhiteCompensation(bool value);
@@ -67,7 +77,12 @@ private:
     static QString LEFT_SUFFIX;
     static QString RIGHT_SUFFIX;
 
-    using RegionMap = std::unordered_map<std::string, LedRange>;
+    static QString ZONE_MAPPINGS_KEY;
+    static QString MONITOR_ADAPTER_KEY;
+    static QString MONITOR_OUTPUT_KEY;
+
+    using RegionMap     = std::unordered_map<std::string, LedRange>;
+    using ZonePartsMap  = std::unordered_map<std::string, std::vector<ZonePart>>; // key: "location|zoneName"
 
     QSettings settings;
 
@@ -78,6 +93,11 @@ private:
     RegionMap rightRegions;
     RegionMap leftRegions;
 
+    ZonePartsMap zoneParts;
+
+    int monitorAdapterIndex = 0;
+    int monitorOutputIndex  = 0;
+
     bool coolWhiteCompensation = true;
 
     int colorTemperatureIndex = 55; // 6500K
@@ -87,9 +107,11 @@ private:
 
     void syncSelectedControllers();
     void syncRegions(const RegionMap &map, const QString &key);
+    void syncZoneMappings();
 
     static void fillRegions(RegionMap &map, const QVariantHash &data);
     [[nodiscard]] static LedRange findRange(const RegionMap &map, const std::string &location);
+    static void fillZoneParts(ZonePartsMap &map, const QVariantHash &data);
 };
 
 #endif //OPENRGB_AMBIENT_SETTINGS_H

--- a/Settings.h
+++ b/Settings.h
@@ -19,6 +19,8 @@
 class ResourceManager;
 class QString;
 
+enum class MappingMode { Standard, Zone };
+
 class Settings final
         : public QObject
 {
@@ -33,6 +35,9 @@ public:
 
     [[nodiscard]] bool isZoneEnabled(const std::string &location, const std::string &zoneName) const;
     void setZoneEnabled(const std::string &location, const std::string &zoneName, bool enabled);
+
+    [[nodiscard]] MappingMode getMappingMode(const std::string &location) const;
+    void setMappingMode(const std::string &location, MappingMode mode);
 
     [[nodiscard]] LedRange getTopRegion(const std::string &location) const;
     [[nodiscard]] LedRange getBottomRegion(const std::string &location) const;
@@ -82,6 +87,7 @@ private:
 
     static QString ZONE_MAPPINGS_KEY;
     static QString DISABLED_ZONES_KEY;
+    static QString ZONE_MAPPING_LOCATIONS_KEY;
     static QString MONITOR_ADAPTER_KEY;
     static QString MONITOR_OUTPUT_KEY;
 
@@ -91,7 +97,8 @@ private:
     QSettings settings;
 
     std::unordered_set<std::string> selectedControllers;
-    std::unordered_set<std::string> disabledZones; // key: "location|zoneName"
+    std::unordered_set<std::string> disabledZones;         // key: "location|zoneName"
+    std::unordered_set<std::string> zoneMappingLocations;  // locations using zone mapping mode
 
     RegionMap topRegions;
     RegionMap bottomRegions;
@@ -112,6 +119,7 @@ private:
 
     void syncSelectedControllers();
     void syncDisabledZones();
+    void syncMappingModes();
     void syncRegions(const RegionMap &map, const QString &key);
     void syncZoneMappings();
 

--- a/SettingsTab.cpp
+++ b/SettingsTab.cpp
@@ -126,9 +126,9 @@ void SettingsTab::updatePreview(const QImage &image) const
     preview->updateFrame(image);
 }
 
-void SettingsTab::updateLedColors(const QString &location, std::vector<RGBColor> colors) const
+void SettingsTab::updateLedColors(const QString &location, const std::vector<RGBColor> &colors) const
 {
-    preview->updateLedColors(location, std::move(colors));
+    preview->updateLedColors(location, colors);
 }
 
 

--- a/SettingsTab.cpp
+++ b/SettingsTab.cpp
@@ -51,7 +51,7 @@ SettingsTab::SettingsTab(ResourceManagerInterface *resourceManager, Settings &se
     const auto topLayout = new QHBoxLayout{};
     const auto previewLayout = new QVBoxLayout{};
 
-    const auto previewBtn = new QCheckBox{"Preview (not supported for HDR)"};
+    const auto previewBtn = new QCheckBox{"Preview"};
     connect(previewBtn, &QCheckBox::stateChanged, this, [=](auto state) {
         emit previewChanged(state == Qt::Checked);
     });

--- a/SettingsTab.cpp
+++ b/SettingsTab.cpp
@@ -12,6 +12,8 @@
 #include "RegionsWidget.h"
 #include "DeviceList.h"
 #include "Settings.h"
+#include "ScreenCapture.h"
+#include "LedPreviewWidget.h"
 
 #include "SettingsTab.h"
 
@@ -19,6 +21,33 @@ SettingsTab::SettingsTab(ResourceManagerInterface *resourceManager, Settings &se
     : QWidget{parent}
 {
     const auto mainLayout = new QVBoxLayout{this};
+
+    // Monitor selection
+    const auto monitorLayout = new QHBoxLayout{};
+    monitorLayout->addWidget(new QLabel{"Monitor:", this});
+
+    const auto monitorCombo = new QComboBox{this};
+    const auto monitors = ScreenCapture::enumerateMonitors();
+    int savedMonitorIdx = 0;
+    for (int i = 0; i < static_cast<int>(monitors.size()); ++i)
+    {
+        const auto &m = monitors[i];
+        monitorCombo->addItem(QString::fromStdString(m.displayName));
+        if (m.adapterIndex == static_cast<UINT>(settings.monitorAdapter()) &&
+            m.outputIndex  == settings.monitorOutput())
+            savedMonitorIdx = i;
+    }
+    monitorCombo->setCurrentIndex(savedMonitorIdx);
+    connect(monitorCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [&, monitors](int index) {
+        if (index < 0 || index >= static_cast<int>(monitors.size()))
+            return;
+        settings.setMonitorAdapter(static_cast<int>(monitors[index].adapterIndex));
+        settings.setMonitorOutput(monitors[index].outputIndex);
+    });
+    monitorLayout->addWidget(monitorCombo);
+    monitorLayout->addStretch();
+    mainLayout->addLayout(monitorLayout);
+
     const auto topLayout = new QHBoxLayout{};
     const auto previewLayout = new QVBoxLayout{};
 
@@ -29,9 +58,7 @@ SettingsTab::SettingsTab(ResourceManagerInterface *resourceManager, Settings &se
 
     previewLayout->addWidget(previewBtn);
 
-    preview = new QLabel{};
-    preview->setMaximumSize(200, 100);
-    preview->setScaledContents(true);
+    preview = new LedPreviewWidget{resourceManager, settings};
 
     previewLayout->addWidget(preview);
 
@@ -96,8 +123,14 @@ SettingsTab::SettingsTab(ResourceManagerInterface *resourceManager, Settings &se
 
 void SettingsTab::updatePreview(const QImage &image) const
 {
-    preview->setPixmap(QPixmap::fromImage(image));
+    preview->updateFrame(image);
 }
+
+void SettingsTab::updateLedColors(const QString &location, std::vector<RGBColor> colors) const
+{
+    preview->updateLedColors(location, std::move(colors));
+}
+
 
 void SettingsTab::showEvent(QShowEvent *event)
 {

--- a/SettingsTab.h
+++ b/SettingsTab.h
@@ -5,11 +5,15 @@
 #ifndef OPENRGB_AMBIENT_SETTINGSTAB_H
 #define OPENRGB_AMBIENT_SETTINGSTAB_H
 
+#include <vector>
+
 #include <QWidget>
+
+#include <RGBController.h>
 
 class ResourceManagerInterface;
 class Settings;
-class QLabel;
+class LedPreviewWidget;
 class QImage;
 
 class SettingsTab
@@ -23,6 +27,7 @@ public:
 
 public slots:
     void updatePreview(const QImage &image) const;
+    void updateLedColors(const QString &location, std::vector<RGBColor> colors) const;
 
 signals:
     void controllerListChanged();
@@ -34,7 +39,7 @@ protected:
     void hideEvent(QHideEvent *event) override;
 
 private:
-    QLabel *preview = nullptr;
+    LedPreviewWidget *preview = nullptr;
 };
 
 #endif //OPENRGB_AMBIENT_SETTINGSTAB_H

--- a/SettingsTab.h
+++ b/SettingsTab.h
@@ -27,7 +27,7 @@ public:
 
 public slots:
     void updatePreview(const QImage &image) const;
-    void updateLedColors(const QString &location, std::vector<RGBColor> colors) const;
+    void updateLedColors(const QString &location, const std::vector<RGBColor> &colors) const;
 
 signals:
     void controllerListChanged();

--- a/ZoneMapping.h
+++ b/ZoneMapping.h
@@ -1,0 +1,36 @@
+//
+
+#ifndef OPENRGB_AMBIENT_ZONEMAPPING_H
+#define OPENRGB_AMBIENT_ZONEMAPPING_H
+
+#include "LedRange.h"
+
+enum class ScreenRegion : int
+{
+    None   = 0,
+    Top    = 1,
+    Bottom = 2,
+    Left   = 3,
+    Right  = 4
+};
+
+// One LED sub-range within a zone mapped to a screen region.
+// from/to are LED indices relative to the zone's start (0-based).
+struct ZonePart
+{
+    int          from     = 0;
+    int          to       = 0;
+    ScreenRegion region   = ScreenRegion::None;
+    bool         reversed = false;
+};
+
+// Computed at processor-build time; passed to ImageProcessor.
+// range holds absolute device LED indices.
+struct ZoneLedRange
+{
+    LedRange     range;
+    ScreenRegion region;
+    bool         reversed;
+};
+
+#endif //OPENRGB_AMBIENT_ZONEMAPPING_H

--- a/ZoneMapping.h
+++ b/ZoneMapping.h
@@ -28,9 +28,9 @@ struct ZonePart
 // range holds absolute device LED indices.
 struct ZoneLedRange
 {
-    LedRange     range;
-    ScreenRegion region;
-    bool         reversed;
+    LedRange     range    = {0, 0};
+    ScreenRegion region   = ScreenRegion::None;
+    bool         reversed = false;
 };
 
 #endif //OPENRGB_AMBIENT_ZONEMAPPING_H


### PR DESCRIPTION
**Beware: 75% of AI slop**

Added LED preview widget, per-zone enable/disable, and selective LED writes

- LedPreviewWidget: shows captured frame thumbnail with LED strip overlays
  on all 4 edges; fixed 320px width, height derived from display proportions;
  colors sourced from ledColorsUpdated signal (post-processed, reversed flag
  already applied — no extra reversal in collectRegionColors)
- HDR preview: nearest-neighbour downsample R10G10B10A2 → RGB32 at 320×(proportional)
  directly during conversion, avoiding full-resolution intermediate image
- DeviceList: replaced QListWidget with QTreeWidget; controllers as parent nodes
  with per-zone child checkboxes; zone items disabled when controller is unchecked
- Settings: zone enable/disable via opt-out model (disabledZones set, absent=enabled);
  persisted as DisabledZones key; backward compatible with existing configs
- processUpdate: selective SetLED — only writes LEDs in mapped (non-None region),
  enabled zone parts; unmapped/disabled zones retain their existing colors
- createProcessor: skips disabled zones when building ZoneLedRange mappings

<img width="856" height="501" alt="image" src="https://github.com/user-attachments/assets/0b081c21-a836-4cf6-855a-60ee43ed6982" />
